### PR TITLE
Fix required llama-cpp-agent version

### DIFF
--- a/cpp_agent_req.txt
+++ b/cpp_agent_req.txt
@@ -1,4 +1,4 @@
-llama-cpp-agent
+llama-cpp-agent==0.0.26
 mkdocs
 mkdocs-material
 mkdocstrings[python]


### PR DESCRIPTION
The `Get Keywords` node fails as llama-cpp-agent has refactored structured output. This moves back to a pre-April 29 2024 version to ensure the API is the expected one.