### PR TITLE
Typing not required after python 3.5+, conflicts with other packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,3 @@ symusic
 torch>=2.0.1
 torchvision>=0.15.2
 transformers>=4.46
-typing


### PR DESCRIPTION
![Screenshot 2025-02-13 at 7 47 21 AM](https://github.com/user-attachments/assets/47d5576a-2896-4648-98e8-23667a053366)
