### PR TITLE
fix: inherit generation mixin since it is seperated from pretrained model

### DIFF
--- a/nodes/moondream/phi/modeling_phi.py
+++ b/nodes/moondream/phi/modeling_phi.py
@@ -16,6 +16,7 @@ from einops import rearrange, repeat
 from transformers import PretrainedConfig, PreTrainedModel
 from transformers.activations import ACT2FN
 from transformers.modeling_outputs import CausalLMOutputWithPast
+from transformers.generation.utils import GenerationMixin
 
 from .configuration_phi import PhiConfig
 
@@ -940,7 +941,7 @@ class PhiModel(PhiPreTrainedModel):
         return hidden_states
 
 
-class PhiForCausalLM(PhiPreTrainedModel):
+class PhiForCausalLM(PhiPreTrainedModel, GenerationMixin):
     """Phi for Causal Language Modeling."""
 
     _keys_to_ignore_on_load_missing = [""]


### PR DESCRIPTION
In the recent versions of the transformers the GenerationMixin inheritence is removed from the PretrainedModel class, so the PhiForCasualLM doesn't have the `generate` method no longer. This PR just inherits it, and seems to solve attribute errors related to this issue.