### PR TITLE
Modernize and secure hosted LLM and VLM APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ComfyUI VLM Nodes
 
 Production-oriented vision-language, structured prompting, audio, and utility
-nodes for ComfyUI. Version 2.3 supports ComfyUI's selected NVIDIA CUDA, AMD
+nodes for ComfyUI. Version 3.1 supports ComfyUI's selected NVIDIA CUDA, AMD
 ROCm, Apple Metal, Intel XPU, and CPU device without replacing its PyTorch
 build. It removes startup installers and global accelerator cache flushes,
 adds real image/video batches and live token streaming, and uses ComfyUI model
@@ -285,10 +285,56 @@ are not available for the installed PyTorch/backend combination.
 
 ## API nodes
 
-`PromptGenerateAPI` supports the current OpenAI Responses API, the legacy Chat
-Completions API, and compatible base URLs. API keys can be supplied by node or
-environment (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`,
-`GROQ_API_KEY`). Keys are never persisted by this repository.
+**Hosted LLM API (Secure)** and **Hosted VLM API (Secure)** share a provider
+layer built around the current OpenAI Responses and Chat Completions request
+shapes, with Anthropic using its native Messages/vision contract. The VLM node
+accepts a still image or a video-frame batch, samples
+frames uniformly, resizes and JPEG-compresses them, and enforces per-image and
+total request limits before upload. Both nodes can stream text into a connected
+`ViewText` node.
+
+Curated production profiles include:
+
+| Provider | Presets | Server environment variable |
+| --- | --- | --- |
+| OpenAI | GPT-5.6 Terra, Sol, Luna | `OPENAI_API_KEY` |
+| Google | Gemini 3.6 Flash, 3.5 Flash, 3.5 Flash-Lite | `GEMINI_API_KEY` |
+| Anthropic | Claude Fable 5, Opus 5, Sonnet 5, Haiku 4.5 | `ANTHROPIC_API_KEY` |
+| xAI | Grok 4.5 | `XAI_API_KEY` |
+| DeepSeek | V4 Flash, V4 Pro | `DEEPSEEK_API_KEY` |
+| Groq | Qwen 3.6 27B Vision, GPT-OSS 20B | `GROQ_API_KEY` |
+| Mistral | Mistral Large, Mistral Small, Ministral 14B | `MISTRAL_API_KEY` |
+| Together AI | Kimi K2.5, Qwen 3.5 9B | `TOGETHER_API_KEY` |
+| OpenRouter | Any compatible model ID | `OPENROUTER_API_KEY` |
+| Custom/local | OpenAI-compatible endpoint | `CUSTOM_API_KEY` |
+
+Preset IDs were reviewed on 2026-07-29 against the official
+[OpenAI](https://developers.openai.com/api/docs/models),
+[Gemini](https://ai.google.dev/gemini-api/docs/models),
+[Claude](https://platform.claude.com/docs/en/about-claude/models/overview),
+[xAI](https://docs.x.ai/developers/models),
+[DeepSeek](https://api-docs.deepseek.com/updates/),
+[Groq](https://console.groq.com/docs/models),
+[Mistral](https://docs.mistral.ai/models/), and
+[Together](https://docs.together.ai/docs/inference/recommended-models), plus
+[OpenRouter's multimodal compatibility](https://openrouter.ai/docs/guides/overview/multimodal/overview)
+catalogs. Use `model_override` when a provider exposes a newer compatible model
+before the next node-pack release.
+
+API keys are not node inputs. A workflow contains only the provider selection,
+and the server resolves that provider's fixed environment variable at execution
+time. Built-in credentials are pinned to the provider's official HTTPS host;
+only the custom profile accepts a URL, and it can read only `CUSTOM_API_KEY`.
+Remote custom URLs require HTTPS, while keyless HTTP is restricted to
+`localhost`/loopback. Redirect following and environment proxies are disabled
+by default, API calls are stateless, OpenAI Responses explicitly use
+`store=false`, and provider exceptions are redacted before ComfyUI receives
+them.
+
+Opening an older `PromptGenerateAPI` workflow automatically clears its former
+plaintext key widget before the graph is configured. Save the migrated workflow
+to overwrite the old file, and rotate any key that was previously saved or
+shared. See [SECURITY.md](SECURITY.md) for setup and the exact threat model.
 
 ## Reliability guarantees
 

--- a/README.md
+++ b/README.md
@@ -287,11 +287,33 @@ are not available for the installed PyTorch/backend combination.
 
 **Hosted LLM API (Secure)** and **Hosted VLM API (Secure)** share a provider
 layer built around the current OpenAI Responses and Chat Completions request
-shapes, with Anthropic using its native Messages/vision contract. The VLM node
+shapes, with Anthropic using its native Messages/vision contract and Gemini
+switching to its native multimodal contract for grounded or structured calls.
+The VLM node
 accepts a still image or a video-frame batch, samples
 frames uniformly, resizes and JPEG-compresses them, and enforces per-image and
 total request limits before upload. Both nodes can stream text into a connected
 `ViewText` node.
+
+Both API nodes also expose:
+
+- **Native web search** for OpenAI, Gemini, Anthropic, xAI, and any compatible
+  model routed through OpenRouter. Unsupported presets fail clearly before a
+  model request instead of silently pretending to search. Search can add
+  provider cost and has provider-specific data terms, so it is off by default.
+- **JSON object** and **JSON Schema** output. Completed JSON is always parsed
+  locally, JSON Schema results are validated locally, and invalid results fail
+  the node instead of flowing into downstream automation.
+- **Open-source structured VLM output** through Custom / Local endpoints.
+  OpenAI-standard mode supports vLLM, Ollama, and compatible servers;
+  `llama.cpp JSON Schema` emits llama.cpp's direct schema dialect; and
+  `JSON object + local validation` is a portable fallback for servers that
+  implement only JSON mode.
+
+User-provided schemas are capped at 64,000 characters, bounded by depth/node
+count, checked against their declared JSON Schema draft, and may use only local
+fragment `$ref` values. Remote/file references are rejected so validation can
+never turn into an unexpected network or filesystem lookup.
 
 Curated production profiles include:
 
@@ -321,6 +343,20 @@ Preset IDs were reviewed on 2026-07-29 against the official
 catalogs. Use `model_override` when a provider exposes a newer compatible model
 before the next node-pack release.
 
+The capability routing follows the current official
+[OpenAI web-search](https://developers.openai.com/api/docs/guides/tools-web-search)
+and [structured-output](https://developers.openai.com/api/docs/guides/structured-outputs)
+contracts,
+[Gemini grounding](https://ai.google.dev/gemini-api/docs/google-search) and
+[structured output](https://ai.google.dev/gemini-api/docs/structured-output),
+[Claude web-search](https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool)
+and [structured-output](https://platform.claude.com/docs/en/build-with-claude/structured-outputs)
+contracts, [xAI web search](https://docs.x.ai/developers/tools/web-search) and
+[structured outputs](https://docs.x.ai/developers/model-capabilities/text/structured-outputs),
+and [OpenRouter server-side search](https://openrouter.ai/docs/guides/features/server-tools/web-search).
+The local dialect is based on the
+[llama.cpp server API](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md).
+
 API keys are not node inputs. A workflow contains only the provider selection,
 and the server resolves that provider's fixed environment variable at execution
 time. Built-in credentials are pinned to the provider's official HTTPS host;
@@ -330,6 +366,10 @@ Remote custom URLs require HTTPS, while keyless HTTP is restricted to
 by default, API calls are stateless, OpenAI Responses explicitly use
 `store=false`, and provider exceptions are redacted before ComfyUI receives
 them.
+
+Web search sends the prompt (and, where supported, the same multimodal request)
+to the selected provider's server-side search system. Do not enable it for
+content that must not be processed under that provider's search terms.
 
 Opening an older `PromptGenerateAPI` workflow automatically clears its former
 plaintext key widget before the graph is configured. Save the migrated workflow

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,75 @@
+# API credential security
+
+## Guarantees
+
+- API keys are never accepted as node inputs, widget values, workflow fields,
+  outputs, metadata, or log messages.
+- Each built-in provider reads only its standard server-side environment
+  variable and sends it only to that provider's fixed official HTTPS endpoint.
+- A built-in provider key cannot be combined with a workflow-supplied URL.
+- The custom endpoint reads only `CUSTOM_API_KEY`. Remote custom endpoints must
+  use HTTPS; unencrypted and keyless requests are limited to loopback.
+- HTTP redirects and environment proxies are disabled by default. Proxy use is
+  an explicit non-secret node option for installations that require it.
+- Hosted calls are stateless. No Python node-instance conversation history is
+  retained, and OpenAI Responses requests set `store=false`.
+- Exceptions are bounded and redact the resolved key, URL-encoded variants,
+  bearer tokens, common provider-key formats, authorization fields, and URL
+  user-info before the message reaches ComfyUI.
+- Local image/video-frame uploads are uniformly sampled, resized,
+  JPEG-compressed, limited to 4 MiB per image, and limited to 24 MiB total.
+
+## Configure credentials
+
+Set the matching variable in the environment that launches ComfyUI, then
+restart ComfyUI:
+
+| Provider | Variable |
+| --- | --- |
+| OpenAI | `OPENAI_API_KEY` |
+| Google Gemini | `GEMINI_API_KEY` |
+| Anthropic | `ANTHROPIC_API_KEY` |
+| xAI | `XAI_API_KEY` |
+| DeepSeek | `DEEPSEEK_API_KEY` |
+| Groq | `GROQ_API_KEY` |
+| Mistral | `MISTRAL_API_KEY` |
+| Together AI | `TOGETHER_API_KEY` |
+| OpenRouter | `OPENROUTER_API_KEY` |
+| Custom remote endpoint | `CUSTOM_API_KEY` |
+
+For an interactive POSIX/WSL session, this avoids putting the value in shell
+history:
+
+```bash
+read -rsp "Provider API key: " OPENAI_API_KEY
+export OPENAI_API_KEY
+python main.py
+```
+
+Use the equivalent secret manager or service environment mechanism for a
+persistent installation. Do not commit a `.env` file, workflow containing an
+old key, shell script containing a key, or copied ComfyUI log.
+
+## Legacy workflows
+
+Versions before this security update exposed an `api_key` text widget.
+The frontend migration clears position 3 of every serialized
+`PromptGenerateAPI` node before LiteGraph creates the active node, including
+nodes inside saved subgraph definitions. The backend independently rejects any
+value that is not one of the two safe credential-source choices.
+
+The source workflow file is not rewritten merely by opening it. Save the
+migrated workflow, securely remove old copies, and rotate any credential that
+was ever saved, shared, committed, backed up, or placed in an exported PNG.
+
+## Threat boundary
+
+ComfyUI custom nodes execute Python code with the permissions of the ComfyUI
+process. Another untrusted custom-node package can read the same process
+environment regardless of protections in this repository. Install only trusted
+node packs, keep ComfyUI authenticated and bound to a trusted interface, and do
+not expose an unauthenticated server to the public internet.
+
+If a key may have been exposed, revoke it with the provider immediately, review
+usage, create a replacement with the minimum needed project permissions and
+spend limit, and restart ComfyUI with the replacement.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,6 +18,10 @@
   user-info before the message reaches ComfyUI.
 - Local image/video-frame uploads are uniformly sampled, resized,
   JPEG-compressed, limited to 4 MiB per image, and limited to 24 MiB total.
+- User JSON Schemas are size/depth/node bounded and may contain only local
+  fragment `$ref` values. Remote URLs and file references are rejected before
+  validation, preventing schema resolution from becoming an SSRF or local-file
+  access path.
 
 ## Configure credentials
 
@@ -49,6 +53,11 @@ python main.py
 Use the equivalent secret manager or service environment mechanism for a
 persistent installation. Do not commit a `.env` file, workflow containing an
 old key, shell script containing a key, or copied ComfyUI log.
+
+Web search is disabled by default. Enabling it sends the request content to the
+selected provider's server-side search system and may have separate retention,
+regional-availability, and billing terms. Treat it as an explicit data-sharing
+choice; do not enable it for content that is outside those terms.
 
 ## Legacy workflows
 

--- a/__init__.py
+++ b/__init__.py
@@ -11,6 +11,7 @@ node_list = [
     "diagnostics",
     "florence2",
     "grounding",
+    "hosted_api",
     "joytag",
     "kosmos2",
     "llavaloader",

--- a/nodes/hosted_api.py
+++ b/nodes/hosted_api.py
@@ -1,0 +1,1306 @@
+"""Secure hosted LLM and VLM API nodes.
+
+Credentials are deliberately server-side only.  Workflows select a provider,
+never an API key or an arbitrary environment variable.  Built-in provider
+credentials are also pinned to built-in HTTPS endpoints so a downloaded
+workflow cannot redirect (for example) ``OPENAI_API_KEY`` to another host.
+Custom endpoints can read only ``CUSTOM_API_KEY``.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import io
+import os
+import re
+from dataclasses import dataclass, replace
+from typing import Any, Callable
+from urllib.parse import quote, quote_plus, urlsplit, urlunsplit
+
+import torch
+from PIL import Image
+
+from .prompts import system_msg_prompts, system_msg_simple
+from .runtime import require_module, tensor_to_pil
+
+PROVIDER_CREDENTIAL = "Provider environment variable"
+LOCAL_NO_KEY = "No key (loopback custom endpoint only)"
+CREDENTIAL_SOURCES = (PROVIDER_CREDENTIAL, LOCAL_NO_KEY)
+API_MODES = ("Auto", "Responses", "Chat Completions")
+REASONING_EFFORTS = (
+    "none",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+)
+IMAGE_DETAILS = ("auto", "low", "high")
+
+MAX_ERROR_CHARS = 800
+MAX_IMAGE_BYTES = 4 * 1024 * 1024
+MAX_TOTAL_MEDIA_BYTES = 24 * 1024 * 1024
+MAX_PROMPT_CHARS = 200_000
+MAX_SYSTEM_PROMPT_CHARS = 32_000
+
+
+@dataclass(frozen=True)
+class ProviderProfile:
+    label: str
+    provider: str
+    model: str
+    api_key_env: str
+    base_url: str | None
+    api_mode: str = "Chat Completions"
+    vision: bool = False
+    responses: bool = False
+    custom_endpoint: bool = False
+    supports_seed: bool = False
+    max_images: int = 8
+
+
+_PROFILES = (
+    ProviderProfile(
+        "OpenAI — GPT-5.6 Terra",
+        "OpenAI",
+        "gpt-5.6-terra",
+        "OPENAI_API_KEY",
+        None,
+        api_mode="Responses",
+        vision=True,
+        responses=True,
+        max_images=32,
+    ),
+    ProviderProfile(
+        "OpenAI — GPT-5.6 Sol",
+        "OpenAI",
+        "gpt-5.6-sol",
+        "OPENAI_API_KEY",
+        None,
+        api_mode="Responses",
+        vision=True,
+        responses=True,
+        max_images=32,
+    ),
+    ProviderProfile(
+        "OpenAI — GPT-5.6 Luna",
+        "OpenAI",
+        "gpt-5.6-luna",
+        "OPENAI_API_KEY",
+        None,
+        api_mode="Responses",
+        vision=True,
+        responses=True,
+        max_images=32,
+    ),
+    ProviderProfile(
+        "Google — Gemini 3.6 Flash",
+        "Google Gemini",
+        "gemini-3.6-flash",
+        "GEMINI_API_KEY",
+        "https://generativelanguage.googleapis.com/v1beta/openai/",
+        vision=True,
+        max_images=32,
+    ),
+    ProviderProfile(
+        "Google — Gemini 3.5 Flash",
+        "Google Gemini",
+        "gemini-3.5-flash",
+        "GEMINI_API_KEY",
+        "https://generativelanguage.googleapis.com/v1beta/openai/",
+        vision=True,
+        max_images=32,
+    ),
+    ProviderProfile(
+        "Google — Gemini 3.5 Flash-Lite",
+        "Google Gemini",
+        "gemini-3.5-flash-lite",
+        "GEMINI_API_KEY",
+        "https://generativelanguage.googleapis.com/v1beta/openai/",
+        vision=True,
+        max_images=32,
+    ),
+    ProviderProfile(
+        "Anthropic — Claude Fable 5",
+        "Anthropic",
+        "claude-fable-5",
+        "ANTHROPIC_API_KEY",
+        "https://api.anthropic.com/v1/",
+        api_mode="Anthropic Messages",
+        vision=True,
+        max_images=20,
+    ),
+    ProviderProfile(
+        "Anthropic — Claude Opus 5",
+        "Anthropic",
+        "claude-opus-5",
+        "ANTHROPIC_API_KEY",
+        "https://api.anthropic.com/v1/",
+        api_mode="Anthropic Messages",
+        vision=True,
+        max_images=20,
+    ),
+    ProviderProfile(
+        "Anthropic — Claude Sonnet 5",
+        "Anthropic",
+        "claude-sonnet-5",
+        "ANTHROPIC_API_KEY",
+        "https://api.anthropic.com/v1/",
+        api_mode="Anthropic Messages",
+        vision=True,
+        max_images=20,
+    ),
+    ProviderProfile(
+        "Anthropic — Claude Haiku 4.5",
+        "Anthropic",
+        "claude-haiku-4-5",
+        "ANTHROPIC_API_KEY",
+        "https://api.anthropic.com/v1/",
+        api_mode="Anthropic Messages",
+        vision=True,
+        max_images=20,
+    ),
+    ProviderProfile(
+        "xAI — Grok 4.5",
+        "xAI",
+        "grok-4.5",
+        "XAI_API_KEY",
+        "https://api.x.ai/v1",
+        api_mode="Responses",
+        vision=True,
+        responses=True,
+        max_images=10,
+    ),
+    ProviderProfile(
+        "DeepSeek — V4 Flash",
+        "DeepSeek",
+        "deepseek-v4-flash",
+        "DEEPSEEK_API_KEY",
+        "https://api.deepseek.com/v1",
+    ),
+    ProviderProfile(
+        "DeepSeek — V4 Pro",
+        "DeepSeek",
+        "deepseek-v4-pro",
+        "DEEPSEEK_API_KEY",
+        "https://api.deepseek.com/v1",
+    ),
+    ProviderProfile(
+        "Groq — Qwen 3.6 27B (vision)",
+        "Groq",
+        "qwen/qwen3.6-27b",
+        "GROQ_API_KEY",
+        "https://api.groq.com/openai/v1",
+        api_mode="Responses",
+        vision=True,
+        responses=True,
+        max_images=5,
+    ),
+    ProviderProfile(
+        "Groq — GPT-OSS 20B",
+        "Groq",
+        "openai/gpt-oss-20b",
+        "GROQ_API_KEY",
+        "https://api.groq.com/openai/v1",
+        api_mode="Responses",
+        responses=True,
+    ),
+    ProviderProfile(
+        "Mistral — Mistral Large (latest)",
+        "Mistral",
+        "mistral-large-latest",
+        "MISTRAL_API_KEY",
+        "https://api.mistral.ai/v1",
+        vision=True,
+    ),
+    ProviderProfile(
+        "Mistral — Mistral Small (latest)",
+        "Mistral",
+        "mistral-small-latest",
+        "MISTRAL_API_KEY",
+        "https://api.mistral.ai/v1",
+        vision=True,
+    ),
+    ProviderProfile(
+        "Mistral — Ministral 14B (latest)",
+        "Mistral",
+        "ministral-14b-latest",
+        "MISTRAL_API_KEY",
+        "https://api.mistral.ai/v1",
+        vision=True,
+    ),
+    ProviderProfile(
+        "Together — Kimi K2.5 (vision)",
+        "Together AI",
+        "moonshotai/Kimi-K2.5",
+        "TOGETHER_API_KEY",
+        "https://api.together.ai/v1",
+        vision=True,
+    ),
+    ProviderProfile(
+        "Together — Qwen 3.5 9B (vision)",
+        "Together AI",
+        "Qwen/Qwen3.5-9B",
+        "TOGETHER_API_KEY",
+        "https://api.together.ai/v1",
+        vision=True,
+    ),
+    ProviderProfile(
+        "OpenRouter — Custom model",
+        "OpenRouter",
+        "",
+        "OPENROUTER_API_KEY",
+        "https://openrouter.ai/api/v1",
+        vision=True,
+    ),
+    ProviderProfile(
+        "Custom / Local — OpenAI compatible",
+        "Custom / Local",
+        "",
+        "CUSTOM_API_KEY",
+        None,
+        vision=True,
+        responses=True,
+        custom_endpoint=True,
+        supports_seed=True,
+        max_images=32,
+    ),
+)
+
+PROVIDER_PROFILES = {profile.label: profile for profile in _PROFILES}
+
+# Old labels remain valid so existing workflows keep their selected model.  The
+# third legacy widget is scrubbed in the frontend before graph configuration.
+_LEGACY_ALIASES = {
+    "GPT-5.6 Terra": "OpenAI — GPT-5.6 Terra",
+    "GPT-5.6 Sol": "OpenAI — GPT-5.6 Sol",
+    "GPT-5.6 Luna": "OpenAI — GPT-5.6 Luna",
+    "DeepSeek": "DeepSeek — V4 Flash",
+    "Custom / OpenAI-compatible": "Custom / Local — OpenAI compatible",
+    "ChatGPT-3.5": "OpenAI — GPT-5.6 Luna",
+    "ChatGPT-4": "OpenAI — GPT-5.6 Terra",
+    "gpt-3.5-turbo": "OpenAI — GPT-5.6 Luna",
+    "gpt-3.5-turbo-0125": "OpenAI — GPT-5.6 Luna",
+    "gpt-35-turbo": "OpenAI — GPT-5.6 Luna",
+    "gpt-3.5-turbo-16k": "OpenAI — GPT-5.6 Luna",
+    "gpt-3.5-turbo-16k-0613": "OpenAI — GPT-5.6 Luna",
+    "gpt-4-0613": "OpenAI — GPT-5.6 Terra",
+    "gpt-4-1106-preview": "OpenAI — GPT-5.6 Terra",
+    "glm-4": "Custom / Local — OpenAI compatible",
+}
+
+API_MODELS = list(PROVIDER_PROFILES) + list(_LEGACY_ALIASES)
+VLM_API_MODELS = [
+    label for label, profile in PROVIDER_PROFILES.items() if profile.vision
+]
+
+
+def provider_profile(label: str) -> ProviderProfile:
+    canonical = _LEGACY_ALIASES.get(label, label)
+    try:
+        profile = PROVIDER_PROFILES[canonical]
+    except KeyError:
+        raise ValueError(
+            "Unknown hosted API provider/model selection. Refresh the node "
+            "definition and choose a current provider."
+        ) from None
+
+    # Preserve the exact legacy model ID only when it represented a real API ID.
+    if label in {
+        "gpt-3.5-turbo",
+        "gpt-3.5-turbo-0125",
+        "gpt-35-turbo",
+        "gpt-3.5-turbo-16k",
+        "gpt-3.5-turbo-16k-0613",
+        "gpt-4-0613",
+        "gpt-4-1106-preview",
+    }:
+        return replace(profile, model=label, api_mode="Chat Completions")
+    return profile
+
+
+def _is_loopback_host(hostname: str | None) -> bool:
+    if not hostname:
+        return False
+    lowered = hostname.rstrip(".").lower()
+    if lowered == "localhost" or lowered.endswith(".localhost"):
+        return True
+    try:
+        return ipaddress.ip_address(lowered).is_loopback
+    except ValueError:
+        return False
+
+
+def validate_custom_base_url(value: str) -> tuple[str, bool]:
+    """Validate and normalize a user-controlled OpenAI-compatible endpoint."""
+
+    raw = (value or "").strip()
+    if not raw:
+        raise ValueError(
+            "Custom / Local requires a base_url. Use HTTPS for remote services "
+            "or an HTTP loopback URL such as http://127.0.0.1:8000/v1."
+        )
+    parsed = urlsplit(raw)
+    if parsed.scheme.lower() not in {"https", "http"} or not parsed.hostname:
+        raise ValueError("base_url must be an absolute HTTP(S) URL.")
+    if parsed.username or parsed.password:
+        raise ValueError("base_url must not contain embedded credentials.")
+    if parsed.query or parsed.fragment:
+        raise ValueError("base_url must not contain a query string or fragment.")
+
+    loopback = _is_loopback_host(parsed.hostname)
+    if parsed.scheme.lower() != "https" and not loopback:
+        raise ValueError("Remote API endpoints must use HTTPS.")
+
+    normalized = urlunsplit(
+        (
+            parsed.scheme.lower(),
+            parsed.netloc,
+            parsed.path.rstrip("/") or "",
+            "",
+            "",
+        )
+    )
+    return normalized, loopback
+
+
+def resolve_endpoint(
+    profile: ProviderProfile, base_url: str
+) -> tuple[str | None, bool]:
+    if profile.custom_endpoint:
+        return validate_custom_base_url(base_url)
+    if (base_url or "").strip():
+        raise ValueError(
+            "For credential safety, base_url overrides are accepted only by "
+            "Custom / Local. Built-in provider keys are pinned to official hosts."
+        )
+    return profile.base_url, False
+
+
+def resolve_api_key(
+    profile: ProviderProfile,
+    credential_source: str,
+    *,
+    loopback: bool,
+) -> str:
+    if credential_source not in CREDENTIAL_SOURCES:
+        raise ValueError(
+            "A legacy plaintext API key was removed from this workflow. "
+            f"Set {profile.api_key_env} in the ComfyUI server environment and "
+            "select 'Provider environment variable'."
+        )
+    if credential_source == LOCAL_NO_KEY:
+        if not (profile.custom_endpoint and loopback):
+            raise ValueError(
+                "'No key' is allowed only for a loopback Custom / Local endpoint."
+            )
+        return "local-no-key"
+
+    value = os.getenv(profile.api_key_env, "").strip()
+    if value:
+        return value
+    if profile.custom_endpoint and loopback:
+        return "local-no-key"
+    raise ValueError(
+        f"No credential is configured for {profile.provider}. Set "
+        f"{profile.api_key_env} in the environment that starts ComfyUI, then "
+        "restart the server. API keys are intentionally not accepted by nodes."
+    )
+
+
+_SECRET_PATTERNS = (
+    re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{8,}"),
+    re.compile(
+        r"(?i)\b(?:api[_-]?key|authorization|x-api-key)\b"
+        r"\s*[=:]\s*[\"']?[^\s,\"'}]{4,}"
+    ),
+    re.compile(r"\b(?:sk-ant-|sk-|xai-|gsk_|AIza)[A-Za-z0-9._-]{8,}"),
+    re.compile(r"(?i)(https?://)[^/@\s:]+:[^/@\s]+@"),
+)
+
+
+def redact_sensitive(value: object, secrets: tuple[str, ...] = ()) -> str:
+    """Return a bounded, key-safe error string."""
+
+    text = str(value)
+    for secret in secrets:
+        if not secret or secret == "local-no-key":
+            continue
+        for variant in {secret, quote(secret, safe=""), quote_plus(secret)}:
+            if variant:
+                text = text.replace(variant, "[REDACTED]")
+    for pattern in _SECRET_PATTERNS:
+        text = pattern.sub("[REDACTED]", text)
+    text = " ".join(text.split())
+    if len(text) > MAX_ERROR_CHARS:
+        text = f"{text[:MAX_ERROR_CHARS]}…"
+    return text
+
+
+def safe_api_error(
+    exc: Exception,
+    profile: ProviderProfile,
+    *,
+    secret: str,
+) -> RuntimeError:
+    status = getattr(exc, "status_code", None)
+    if not isinstance(status, int):
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+    status_text = f" (HTTP {status})" if isinstance(status, int) else ""
+    detail = redact_sensitive(exc, (secret,))
+    if not detail:
+        detail = type(exc).__name__
+    return RuntimeError(f"{profile.provider} API request failed{status_text}: {detail}")
+
+
+def _progress_text_sender(node_id: str | None) -> Callable[[str], None] | None:
+    if node_id is None:
+        return None
+    try:
+        from server import PromptServer
+
+        server = PromptServer.instance
+    except (ImportError, AttributeError):
+        return None
+
+    def send(text: str) -> None:
+        try:
+            server.send_progress_text(text, str(node_id), server.client_id)
+        except Exception:
+            return
+
+    return send
+
+
+def _uniform_indices(total: int, limit: int) -> list[int]:
+    if total <= 0:
+        return []
+    count = min(total, max(1, int(limit)))
+    if count == 1:
+        return [0]
+    return sorted(
+        {
+            round(index * (total - 1) / (count - 1))
+            for index in range(count)
+        }
+    )
+
+
+def _fit_image(image: Image.Image, max_edge: int) -> Image.Image:
+    value = image.convert("RGB")
+    edge = max(value.size)
+    if edge <= max_edge:
+        return value
+    scale = max_edge / edge
+    size = (
+        max(1, round(value.width * scale)),
+        max(1, round(value.height * scale)),
+    )
+    return value.resize(size, Image.Resampling.LANCZOS)
+
+
+def _jpeg_data_uri(
+    image: Image.Image,
+    *,
+    max_edge: int,
+    quality: int,
+) -> tuple[str, int]:
+    value = _fit_image(image, max_edge)
+    current_quality = max(45, min(95, int(quality)))
+    while True:
+        buffer = io.BytesIO()
+        value.save(
+            buffer,
+            format="JPEG",
+            quality=current_quality,
+            optimize=True,
+            progressive=True,
+        )
+        payload = buffer.getvalue()
+        if len(payload) <= MAX_IMAGE_BYTES:
+            break
+        if max(value.size) <= 512:
+            raise ValueError(
+                "A sampled frame could not be compressed below the 4 MiB safety limit."
+            )
+        value = _fit_image(value, max(512, round(max(value.size) * 0.8)))
+        current_quality = max(45, current_quality - 10)
+
+    import base64
+
+    encoded = base64.b64encode(payload).decode("ascii")
+    return f"data:image/jpeg;base64,{encoded}", len(payload)
+
+
+def encode_image_batch(
+    images: torch.Tensor,
+    *,
+    max_frames: int,
+    max_image_edge: int,
+    jpeg_quality: int,
+) -> list[str]:
+    if not isinstance(images, torch.Tensor):
+        raise TypeError("images must be a ComfyUI IMAGE tensor.")
+    if images.ndim == 3:
+        total = 1
+    elif images.ndim == 4:
+        total = int(images.shape[0])
+    else:
+        raise ValueError(f"Expected an HWC/BHWC IMAGE batch, got {tuple(images.shape)}.")
+
+    output: list[str] = []
+    total_bytes = 0
+    for index in _uniform_indices(total, max_frames):
+        pil_image = tensor_to_pil(images, index if images.ndim == 4 else 0)
+        data_uri, payload_bytes = _jpeg_data_uri(
+            pil_image,
+            max_edge=max_image_edge,
+            quality=jpeg_quality,
+        )
+        if total_bytes + payload_bytes > MAX_TOTAL_MEDIA_BYTES:
+            break
+        output.append(data_uri)
+        total_bytes += payload_bytes
+    if not output:
+        raise ValueError("No image frames fit within the 24 MiB request safety limit.")
+    return output
+
+
+def _chat_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") in {
+                "text",
+                "output_text",
+            }:
+                parts.append(str(item.get("text", "")))
+            elif getattr(item, "text", None):
+                parts.append(str(item.text))
+        return "".join(parts)
+    return str(content or "")
+
+
+def _bounded_text(name: str, value: object, limit: int) -> str:
+    text = str(value or "").strip()
+    if len(text) > limit:
+        raise ValueError(
+            f"{name} is {len(text):,} characters; the safety limit is {limit:,}."
+        )
+    return text
+
+
+def _stream_responses(client: Any, request: dict[str, Any], sender) -> str:
+    stream = client.responses.create(**request, stream=True)
+    chunks: list[str] = []
+    try:
+        for event in stream:
+            if getattr(event, "type", "") != "response.output_text.delta":
+                continue
+            delta = str(getattr(event, "delta", "") or "")
+            if not delta:
+                continue
+            chunks.append(delta)
+            if sender is not None:
+                sender("".join(chunks))
+    finally:
+        close = getattr(stream, "close", None)
+        if close is not None:
+            close()
+    return "".join(chunks).strip()
+
+
+def _stream_chat(client: Any, request: dict[str, Any], sender) -> str:
+    stream = client.chat.completions.create(**request, stream=True)
+    chunks: list[str] = []
+    try:
+        for chunk in stream:
+            choices = getattr(chunk, "choices", None) or []
+            if not choices:
+                continue
+            delta = _chat_text(getattr(choices[0].delta, "content", ""))
+            if not delta:
+                continue
+            chunks.append(delta)
+            if sender is not None:
+                sender("".join(chunks))
+    finally:
+        close = getattr(stream, "close", None)
+        if close is not None:
+            close()
+    return "".join(chunks).strip()
+
+
+def _anthropic_image_source(data_uri: str) -> dict[str, Any]:
+    try:
+        header, data = data_uri.split(",", 1)
+        media_type = header.split(";", 1)[0].split(":", 1)[1]
+    except (IndexError, ValueError):
+        raise ValueError("Invalid image data URI for Anthropic Messages.") from None
+    if media_type not in {"image/jpeg", "image/png", "image/webp", "image/gif"}:
+        raise ValueError(f"Unsupported Anthropic image media type: {media_type}.")
+    return {
+        "type": "base64",
+        "media_type": media_type,
+        "data": data,
+    }
+
+
+def _anthropic_response_text(payload: dict[str, Any]) -> str:
+    content = payload.get("content")
+    if not isinstance(content, list):
+        return ""
+    return "".join(
+        str(block.get("text", ""))
+        for block in content
+        if isinstance(block, dict) and block.get("type") == "text"
+    ).strip()
+
+
+def _call_anthropic_api(
+    *,
+    profile: ProviderProfile,
+    model: str,
+    endpoint: str,
+    api_key: str,
+    system_prompt: str,
+    prompt: str,
+    image_data: list[str],
+    timeout_seconds: float,
+    max_output_tokens: int,
+    stream_output: bool,
+    use_system_proxy: bool,
+    unique_id: str | None,
+) -> str:
+    """Use Anthropic's native Messages contract, including native vision."""
+
+    httpx = require_module("httpx", "httpx")
+    content: list[dict[str, Any]] = [{"type": "text", "text": prompt}]
+    content.extend(
+        {
+            "type": "image",
+            "source": _anthropic_image_source(data_uri),
+        }
+        for data_uri in image_data
+    )
+    request = {
+        "model": model,
+        "system": system_prompt,
+        "messages": [{"role": "user", "content": content}],
+        "max_tokens": int(max_output_tokens),
+        "stream": bool(stream_output),
+    }
+    headers = {
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+    }
+    sender = _progress_text_sender(unique_id) if stream_output else None
+    if sender is not None:
+        sender("Connecting securely…")
+
+    client = httpx.Client(
+        timeout=float(timeout_seconds),
+        follow_redirects=False,
+        trust_env=bool(use_system_proxy),
+    )
+    try:
+        url = f"{endpoint.rstrip('/')}/messages"
+        if stream_output:
+            chunks: list[str] = []
+            with client.stream(
+                "POST",
+                url,
+                headers=headers,
+                json=request,
+            ) as response:
+                response.raise_for_status()
+                for line in response.iter_lines():
+                    if not line.startswith("data:"):
+                        continue
+                    raw = line[5:].strip()
+                    if not raw or raw == "[DONE]":
+                        continue
+                    try:
+                        event = json.loads(raw)
+                    except json.JSONDecodeError:
+                        continue
+                    delta = event.get("delta", {})
+                    if (
+                        event.get("type") != "content_block_delta"
+                        or delta.get("type") != "text_delta"
+                    ):
+                        continue
+                    text = str(delta.get("text", "") or "")
+                    if not text:
+                        continue
+                    chunks.append(text)
+                    if sender is not None:
+                        sender("".join(chunks))
+            result = "".join(chunks).strip()
+        else:
+            response = client.post(
+                url,
+                headers=headers,
+                json=request,
+            )
+            response.raise_for_status()
+            result = _anthropic_response_text(response.json())
+        if not result:
+            raise RuntimeError("Anthropic returned an empty text response.")
+        if sender is not None:
+            sender(result)
+        return result
+    except Exception as exc:
+        raise safe_api_error(exc, profile, secret=api_key) from None
+    finally:
+        client.close()
+
+
+def _call_hosted_api(
+    *,
+    profile: ProviderProfile,
+    model: str,
+    endpoint: str | None,
+    api_key: str,
+    mode: str,
+    system_prompt: str,
+    prompt: str,
+    image_data: list[str],
+    image_detail: str,
+    timeout_seconds: float,
+    max_output_tokens: int,
+    reasoning_effort: str,
+    seed: int,
+    stream_output: bool,
+    use_system_proxy: bool,
+    unique_id: str | None,
+) -> str:
+    if image_detail not in IMAGE_DETAILS:
+        raise ValueError(f"image_detail must be one of {IMAGE_DETAILS}.")
+    if reasoning_effort not in REASONING_EFFORTS:
+        raise ValueError(f"reasoning_effort must be one of {REASONING_EFFORTS}.")
+    if mode == "Anthropic Messages":
+        if not endpoint:
+            raise ValueError("Anthropic Messages requires its fixed API endpoint.")
+        return _call_anthropic_api(
+            profile=profile,
+            model=model,
+            endpoint=endpoint,
+            api_key=api_key,
+            system_prompt=system_prompt,
+            prompt=prompt,
+            image_data=image_data,
+            timeout_seconds=timeout_seconds,
+            max_output_tokens=max_output_tokens,
+            stream_output=stream_output,
+            use_system_proxy=use_system_proxy,
+            unique_id=unique_id,
+        )
+    openai = require_module("openai", "openai>=2,<3")
+    client_kwargs: dict[str, Any] = {
+        "api_key": api_key,
+        "timeout": float(timeout_seconds),
+        "max_retries": 2,
+    }
+    if endpoint:
+        client_kwargs["base_url"] = endpoint
+
+    http_client_class = getattr(openai, "DefaultHttpxClient", None)
+    if http_client_class is not None:
+        client_kwargs["http_client"] = http_client_class(
+            follow_redirects=False,
+            trust_env=bool(use_system_proxy),
+            timeout=float(timeout_seconds),
+        )
+
+    client = None
+    sender = _progress_text_sender(unique_id) if stream_output else None
+    if sender is not None:
+        sender("Connecting securely…")
+    try:
+        client = openai.OpenAI(**client_kwargs)
+        if mode == "Responses":
+            content: list[dict[str, Any]] = [
+                {"type": "input_text", "text": prompt}
+            ]
+            content.extend(
+                {
+                    "type": "input_image",
+                    "image_url": data_uri,
+                    "detail": image_detail,
+                }
+                for data_uri in image_data
+            )
+            request: dict[str, Any] = {
+                "model": model,
+                "instructions": system_prompt,
+                "input": [{"role": "user", "content": content}],
+                "max_output_tokens": int(max_output_tokens),
+            }
+            if profile.provider == "OpenAI":
+                request["store"] = False
+                if reasoning_effort != "none":
+                    request["reasoning"] = {"effort": reasoning_effort}
+            if stream_output:
+                result = _stream_responses(client, request, sender)
+            else:
+                response = client.responses.create(**request)
+                result = str(getattr(response, "output_text", "") or "").strip()
+        else:
+            if image_data:
+                user_content: str | list[dict[str, Any]] = [
+                    {"type": "text", "text": prompt},
+                    *[
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": data_uri,
+                                "detail": image_detail,
+                            },
+                        }
+                        for data_uri in image_data
+                    ],
+                ]
+            else:
+                user_content = prompt
+            request = {
+                "model": model,
+                "messages": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_content},
+                ],
+                "max_tokens": int(max_output_tokens),
+            }
+            if profile.supports_seed and int(seed):
+                request["seed"] = int(seed)
+            if stream_output:
+                result = _stream_chat(client, request, sender)
+            else:
+                completion = client.chat.completions.create(**request)
+                choices = getattr(completion, "choices", None) or []
+                result = (
+                    _chat_text(getattr(choices[0].message, "content", "")).strip()
+                    if choices
+                    else ""
+                )
+        if not result:
+            raise RuntimeError("The provider returned an empty text response.")
+        if sender is not None:
+            sender(result)
+        return result
+    except Exception as exc:
+        raise safe_api_error(exc, profile, secret=api_key) from None
+    finally:
+        if client is not None:
+            try:
+                client.close()
+            except Exception:
+                pass
+
+
+def execute_hosted(
+    *,
+    model_name: str,
+    credential_source: str,
+    prompt: str,
+    system_prompt: str,
+    base_url: str,
+    model_override: str,
+    api_mode: str,
+    timeout_seconds: float,
+    max_output_tokens: int,
+    reasoning_effort: str,
+    seed: int,
+    stream_output: bool,
+    use_system_proxy: bool,
+    unique_id: str | None,
+    image_data: list[str] | None = None,
+) -> tuple[str, str, ProviderProfile]:
+    profile = provider_profile(model_name)
+    model = (model_override or profile.model).strip()
+    if not model:
+        raise ValueError(
+            f"A model_override is required for {profile.label}."
+        )
+    images = image_data or []
+    if images and not profile.vision:
+        raise ValueError(f"{profile.label} is not configured for image input.")
+
+    endpoint, loopback = resolve_endpoint(profile, base_url)
+    api_key = resolve_api_key(
+        profile,
+        credential_source,
+        loopback=loopback,
+    )
+    mode = profile.api_mode if api_mode == "Auto" else api_mode
+    if mode not in {"Responses", "Chat Completions", "Anthropic Messages"}:
+        raise ValueError("api_mode must be Auto, Responses, or Chat Completions.")
+    if mode == "Responses" and not profile.responses:
+        raise ValueError(
+            f"{profile.provider} is configured for Chat Completions. "
+            "Use Auto unless its official compatibility layer adds Responses."
+        )
+    safe_prompt = _bounded_text("prompt", prompt, MAX_PROMPT_CHARS)
+    safe_system_prompt = _bounded_text(
+        "system_prompt",
+        system_prompt,
+        MAX_SYSTEM_PROMPT_CHARS,
+    )
+    result = _call_hosted_api(
+        profile=profile,
+        model=model,
+        endpoint=endpoint,
+        api_key=api_key,
+        mode=mode,
+        system_prompt=safe_system_prompt,
+        prompt=safe_prompt,
+        image_data=images,
+        image_detail=IMAGE_DETAILS[0],
+        timeout_seconds=max(1.0, min(1800.0, float(timeout_seconds))),
+        max_output_tokens=max(1, min(131072, int(max_output_tokens))),
+        reasoning_effort=reasoning_effort,
+        seed=seed,
+        stream_output=bool(stream_output),
+        use_system_proxy=bool(use_system_proxy),
+        unique_id=unique_id,
+    )
+    return result, model, profile
+
+
+class PromptGenerateAPI:
+    """Backwards-compatible class name for the secure hosted LLM node."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "model_name": (
+                    API_MODELS,
+                    {"default": "OpenAI — GPT-5.6 Sol"},
+                ),
+                "chat_type": (
+                    "BOOLEAN",
+                    {
+                        "default": True,
+                        "label_on": "Prompt Generator",
+                        "label_off": "Simple Chat",
+                    },
+                ),
+                # Kept in the old api_key widget position. It never accepts a key.
+                "credential_source": (
+                    CREDENTIAL_SOURCES,
+                    {
+                        "default": PROVIDER_CREDENTIAL,
+                        "tooltip": (
+                            "Keys stay in the ComfyUI server environment and are "
+                            "never serialized into the workflow."
+                        ),
+                    },
+                ),
+                "description": ("STRING", {"multiline": True, "default": ""}),
+                "question": ("STRING", {"multiline": True, "default": ""}),
+                "context_size": (
+                    "INT",
+                    {
+                        "default": 0,
+                        "min": 0,
+                        "max": 30,
+                        "step": 1,
+                        "tooltip": (
+                            "Legacy slot retained for workflow compatibility. "
+                            "Hosted calls are stateless for privacy."
+                        ),
+                    },
+                ),
+                "seed": (
+                    "INT",
+                    {
+                        "default": 0,
+                        "min": 0,
+                        "max": 0xFFFFFFFFFFFFFFFF,
+                        "step": 1,
+                    },
+                ),
+            },
+            "optional": {
+                "base_url": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "tooltip": (
+                            "Custom / Local only. Remote URLs require HTTPS; "
+                            "HTTP is allowed only for loopback."
+                        ),
+                    },
+                ),
+                "model_override": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "tooltip": "Exact provider model ID. Overrides the preset.",
+                    },
+                ),
+                "api_mode": (API_MODES, {"default": "Auto"}),
+                "timeout_seconds": (
+                    "FLOAT",
+                    {"default": 120.0, "min": 1.0, "max": 1800.0},
+                ),
+                "reasoning_effort": (
+                    REASONING_EFFORTS,
+                    {"default": "none"},
+                ),
+                "max_output_tokens": (
+                    "INT",
+                    {"default": 4096, "min": 1, "max": 131072},
+                ),
+                "stream_output": ("BOOLEAN", {"default": True}),
+                "use_system_proxy": (
+                    "BOOLEAN",
+                    {
+                        "default": False,
+                        "tooltip": (
+                            "Opt in to HTTP(S)_PROXY from the server environment."
+                        ),
+                    },
+                ),
+            },
+            "hidden": {"unique_id": "UNIQUE_ID"},
+        }
+
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("text",)
+    FUNCTION = "generate_prompt"
+    CATEGORY = "VLM Nodes/API"
+    DESCRIPTION = (
+        "Stateless hosted LLM access with provider-bound environment credentials, "
+        "redacted errors, HTTPS enforcement, and optional live text streaming."
+    )
+
+    def generate_prompt(
+        self,
+        model_name,
+        chat_type,
+        credential_source,
+        description,
+        question,
+        context_size,
+        seed,
+        base_url="",
+        model_override="",
+        api_mode="Auto",
+        timeout_seconds=120.0,
+        reasoning_effort="none",
+        max_output_tokens=4096,
+        stream_output=True,
+        use_system_proxy=False,
+        unique_id=None,
+    ):
+        del context_size
+        prompt = (
+            f"Description:\n{str(description).strip()}\n\n"
+            f"Optional question:\n{str(question).strip()}"
+        ).strip()
+        result, _model, _profile = execute_hosted(
+            model_name=model_name,
+            credential_source=credential_source,
+            prompt=prompt,
+            system_prompt=system_msg_prompts if chat_type else system_msg_simple,
+            base_url=base_url,
+            model_override=model_override,
+            api_mode=api_mode,
+            timeout_seconds=timeout_seconds,
+            max_output_tokens=max_output_tokens,
+            reasoning_effort=reasoning_effort,
+            seed=seed,
+            stream_output=stream_output,
+            use_system_proxy=use_system_proxy,
+            unique_id=unique_id,
+        )
+        return (result,)
+
+
+class HostedVLMAPI:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "model_name": (
+                    VLM_API_MODELS,
+                    {"default": "OpenAI — GPT-5.6 Sol"},
+                ),
+                "credential_source": (
+                    CREDENTIAL_SOURCES,
+                    {"default": PROVIDER_CREDENTIAL},
+                ),
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "Describe the important visual details.",
+                    },
+                ),
+                "system_prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": (
+                            "You are a precise visual assistant. Distinguish "
+                            "observations from uncertain inferences."
+                        ),
+                    },
+                ),
+                "max_frames": (
+                    "INT",
+                    {"default": 8, "min": 1, "max": 32, "step": 1},
+                ),
+                "max_image_edge": (
+                    "INT",
+                    {"default": 1536, "min": 256, "max": 2048, "step": 64},
+                ),
+                "jpeg_quality": (
+                    "INT",
+                    {"default": 88, "min": 45, "max": 95, "step": 1},
+                ),
+                "image_detail": (IMAGE_DETAILS, {"default": "auto"}),
+            },
+            "optional": {
+                "images": ("IMAGE",),
+                "base_url": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "tooltip": (
+                            "Custom / Local only. Remote URLs require HTTPS."
+                        ),
+                    },
+                ),
+                "model_override": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "tooltip": (
+                            "Required for OpenRouter/Custom; optional for presets."
+                        ),
+                    },
+                ),
+                "api_mode": (API_MODES, {"default": "Auto"}),
+                "timeout_seconds": (
+                    "FLOAT",
+                    {"default": 180.0, "min": 1.0, "max": 1800.0},
+                ),
+                "max_output_tokens": (
+                    "INT",
+                    {"default": 4096, "min": 1, "max": 131072},
+                ),
+                "reasoning_effort": (
+                    REASONING_EFFORTS,
+                    {"default": "none"},
+                ),
+                "stream_output": ("BOOLEAN", {"default": True}),
+                "use_system_proxy": ("BOOLEAN", {"default": False}),
+            },
+            "hidden": {"unique_id": "UNIQUE_ID"},
+        }
+
+    RETURN_TYPES = ("STRING", "STRING", "INT")
+    RETURN_NAMES = ("text", "model_used", "frames_sent")
+    FUNCTION = "analyze"
+    CATEGORY = "VLM Nodes/API"
+    DESCRIPTION = (
+        "Secure hosted image and sampled-video-frame understanding. Local images "
+        "are resized, JPEG-compressed, and bounded before upload."
+    )
+
+    def analyze(
+        self,
+        model_name,
+        credential_source,
+        prompt,
+        system_prompt,
+        max_frames,
+        max_image_edge,
+        jpeg_quality,
+        image_detail,
+        images=None,
+        base_url="",
+        model_override="",
+        api_mode="Auto",
+        timeout_seconds=180.0,
+        max_output_tokens=4096,
+        reasoning_effort="none",
+        stream_output=True,
+        use_system_proxy=False,
+        unique_id=None,
+    ):
+        profile = provider_profile(model_name)
+        image_data = (
+            encode_image_batch(
+                images,
+                max_frames=min(int(max_frames), profile.max_images),
+                max_image_edge=max_image_edge,
+                jpeg_quality=jpeg_quality,
+            )
+            if images is not None
+            else []
+        )
+        model = (model_override or profile.model).strip()
+        if not model:
+            raise ValueError(f"A model_override is required for {profile.label}.")
+        if image_data and not profile.vision:
+            raise ValueError(f"{profile.label} does not accept image input.")
+
+        endpoint, loopback = resolve_endpoint(profile, base_url)
+        api_key = resolve_api_key(
+            profile,
+            credential_source,
+            loopback=loopback,
+        )
+        mode = profile.api_mode if api_mode == "Auto" else api_mode
+        if mode not in {"Responses", "Chat Completions", "Anthropic Messages"}:
+            raise ValueError(
+                "api_mode must be Auto, Responses, or Chat Completions."
+            )
+        if mode == "Responses" and not profile.responses:
+            raise ValueError(
+                f"{profile.provider} is configured for Chat Completions. Use Auto."
+            )
+        safe_prompt = _bounded_text("prompt", prompt, MAX_PROMPT_CHARS)
+        safe_system_prompt = _bounded_text(
+            "system_prompt",
+            system_prompt,
+            MAX_SYSTEM_PROMPT_CHARS,
+        )
+        result = _call_hosted_api(
+            profile=profile,
+            model=model,
+            endpoint=endpoint,
+            api_key=api_key,
+            mode=mode,
+            system_prompt=safe_system_prompt,
+            prompt=safe_prompt,
+            image_data=image_data,
+            image_detail=image_detail,
+            timeout_seconds=max(1.0, min(1800.0, float(timeout_seconds))),
+            max_output_tokens=max(1, min(131072, int(max_output_tokens))),
+            reasoning_effort=reasoning_effort,
+            seed=0,
+            stream_output=stream_output,
+            use_system_proxy=use_system_proxy,
+            unique_id=unique_id,
+        )
+        return result, model, len(image_data)
+
+
+NODE_CLASS_MAPPINGS = {
+    "PromptGenerateAPI": PromptGenerateAPI,
+    "HostedVLMAPI": HostedVLMAPI,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "PromptGenerateAPI": "Hosted LLM API (Secure)",
+    "HostedVLMAPI": "Hosted VLM API (Secure)",
+}

--- a/nodes/hosted_api.py
+++ b/nodes/hosted_api.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import ipaddress
 import io
+import json
 import os
 import re
 from dataclasses import dataclass, replace
@@ -37,12 +38,22 @@ REASONING_EFFORTS = (
     "max",
 )
 IMAGE_DETAILS = ("auto", "low", "high")
+OUTPUT_FORMATS = ("Text", "JSON object", "JSON Schema")
+SCHEMA_API_STYLES = (
+    "Auto (provider native)",
+    "OpenAI JSON Schema",
+    "llama.cpp JSON Schema",
+    "JSON object + local validation",
+)
 
 MAX_ERROR_CHARS = 800
 MAX_IMAGE_BYTES = 4 * 1024 * 1024
 MAX_TOTAL_MEDIA_BYTES = 24 * 1024 * 1024
 MAX_PROMPT_CHARS = 200_000
 MAX_SYSTEM_PROMPT_CHARS = 32_000
+MAX_SCHEMA_CHARS = 64_000
+MAX_SCHEMA_DEPTH = 32
+MAX_SCHEMA_NODES = 4096
 
 
 @dataclass(frozen=True)
@@ -58,6 +69,8 @@ class ProviderProfile:
     custom_endpoint: bool = False
     supports_seed: bool = False
     max_images: int = 8
+    web_search: str = "none"
+    schema_api_style: str = "openai"
 
 
 _PROFILES = (
@@ -71,6 +84,7 @@ _PROFILES = (
         vision=True,
         responses=True,
         max_images=32,
+        web_search="responses",
     ),
     ProviderProfile(
         "OpenAI — GPT-5.6 Sol",
@@ -82,6 +96,7 @@ _PROFILES = (
         vision=True,
         responses=True,
         max_images=32,
+        web_search="responses",
     ),
     ProviderProfile(
         "OpenAI — GPT-5.6 Luna",
@@ -93,6 +108,7 @@ _PROFILES = (
         vision=True,
         responses=True,
         max_images=32,
+        web_search="responses",
     ),
     ProviderProfile(
         "Google — Gemini 3.6 Flash",
@@ -102,6 +118,7 @@ _PROFILES = (
         "https://generativelanguage.googleapis.com/v1beta/openai/",
         vision=True,
         max_images=32,
+        web_search="gemini",
     ),
     ProviderProfile(
         "Google — Gemini 3.5 Flash",
@@ -111,6 +128,7 @@ _PROFILES = (
         "https://generativelanguage.googleapis.com/v1beta/openai/",
         vision=True,
         max_images=32,
+        web_search="gemini",
     ),
     ProviderProfile(
         "Google — Gemini 3.5 Flash-Lite",
@@ -120,6 +138,7 @@ _PROFILES = (
         "https://generativelanguage.googleapis.com/v1beta/openai/",
         vision=True,
         max_images=32,
+        web_search="gemini",
     ),
     ProviderProfile(
         "Anthropic — Claude Fable 5",
@@ -130,6 +149,7 @@ _PROFILES = (
         api_mode="Anthropic Messages",
         vision=True,
         max_images=20,
+        web_search="anthropic",
     ),
     ProviderProfile(
         "Anthropic — Claude Opus 5",
@@ -140,6 +160,7 @@ _PROFILES = (
         api_mode="Anthropic Messages",
         vision=True,
         max_images=20,
+        web_search="anthropic",
     ),
     ProviderProfile(
         "Anthropic — Claude Sonnet 5",
@@ -150,6 +171,7 @@ _PROFILES = (
         api_mode="Anthropic Messages",
         vision=True,
         max_images=20,
+        web_search="anthropic",
     ),
     ProviderProfile(
         "Anthropic — Claude Haiku 4.5",
@@ -160,6 +182,7 @@ _PROFILES = (
         api_mode="Anthropic Messages",
         vision=True,
         max_images=20,
+        web_search="anthropic",
     ),
     ProviderProfile(
         "xAI — Grok 4.5",
@@ -171,6 +194,7 @@ _PROFILES = (
         vision=True,
         responses=True,
         max_images=10,
+        web_search="responses",
     ),
     ProviderProfile(
         "DeepSeek — V4 Flash",
@@ -178,6 +202,7 @@ _PROFILES = (
         "deepseek-v4-flash",
         "DEEPSEEK_API_KEY",
         "https://api.deepseek.com/v1",
+        schema_api_style="json_object",
     ),
     ProviderProfile(
         "DeepSeek — V4 Pro",
@@ -185,6 +210,7 @@ _PROFILES = (
         "deepseek-v4-pro",
         "DEEPSEEK_API_KEY",
         "https://api.deepseek.com/v1",
+        schema_api_style="json_object",
     ),
     ProviderProfile(
         "Groq — Qwen 3.6 27B (vision)",
@@ -196,6 +222,7 @@ _PROFILES = (
         vision=True,
         responses=True,
         max_images=5,
+        schema_api_style="json_object",
     ),
     ProviderProfile(
         "Groq — GPT-OSS 20B",
@@ -205,6 +232,7 @@ _PROFILES = (
         "https://api.groq.com/openai/v1",
         api_mode="Responses",
         responses=True,
+        schema_api_style="openai",
     ),
     ProviderProfile(
         "Mistral — Mistral Large (latest)",
@@ -253,6 +281,7 @@ _PROFILES = (
         "OPENROUTER_API_KEY",
         "https://openrouter.ai/api/v1",
         vision=True,
+        web_search="openrouter",
     ),
     ProviderProfile(
         "Custom / Local — OpenAI compatible",
@@ -593,6 +622,177 @@ def _bounded_text(name: str, value: object, limit: int) -> str:
     return text
 
 
+def _walk_json_schema(value: Any, *, depth: int = 0) -> int:
+    """Bound a user schema and reject references that could resolve off-server."""
+
+    if depth > MAX_SCHEMA_DEPTH:
+        raise ValueError(
+            f"json_schema exceeds the maximum nesting depth of {MAX_SCHEMA_DEPTH}."
+        )
+    nodes = 1
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise ValueError("json_schema object keys must be strings.")
+            if key in {"$ref", "$dynamicRef", "$recursiveRef"} and (
+                not isinstance(item, str) or not item.startswith("#")
+            ):
+                raise ValueError(
+                    "json_schema allows only local fragment reference values; "
+                    "remote and file references are blocked."
+                )
+            nodes += _walk_json_schema(item, depth=depth + 1)
+    elif isinstance(value, list):
+        for item in value:
+            nodes += _walk_json_schema(item, depth=depth + 1)
+    if nodes > MAX_SCHEMA_NODES:
+        raise ValueError(
+            f"json_schema exceeds the {MAX_SCHEMA_NODES:,}-node safety limit."
+        )
+    return nodes
+
+
+def parse_json_schema(output_format: str, raw_schema: object) -> dict[str, Any] | None:
+    if output_format not in OUTPUT_FORMATS:
+        raise ValueError(f"output_format must be one of {OUTPUT_FORMATS}.")
+    if output_format != "JSON Schema":
+        return None
+
+    text = _bounded_text("json_schema", raw_schema, MAX_SCHEMA_CHARS)
+    if not text:
+        raise ValueError("JSON Schema output requires a json_schema value.")
+    try:
+        schema = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"json_schema is not valid JSON (line {exc.lineno}, column {exc.colno})."
+        ) from None
+    if not isinstance(schema, dict):
+        raise ValueError("json_schema must be a JSON object.")
+    _walk_json_schema(schema)
+
+    jsonschema = require_module("jsonschema", "jsonschema>=4.22,<5")
+    try:
+        validator_class = jsonschema.validators.validator_for(schema)
+        validator_class.check_schema(schema)
+    except Exception:
+        raise ValueError(
+            "json_schema is not valid for its declared JSON Schema draft."
+        ) from None
+    return schema
+
+
+def _schema_path(path: Any) -> str:
+    output = "$"
+    for item in path:
+        if isinstance(item, int):
+            output += f"[{item}]"
+        elif re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", str(item)):
+            output += f".{item}"
+        else:
+            output += f"[{json.dumps(str(item), ensure_ascii=True)}]"
+    return output
+
+
+def validate_structured_output(
+    result: str,
+    output_format: str,
+    schema: dict[str, Any] | None,
+) -> str:
+    """Parse, locally validate, and normalize completed structured output."""
+
+    if output_format == "Text":
+        return result
+    candidate = result.strip()
+    if candidate.startswith("```") and candidate.endswith("```"):
+        first_newline = candidate.find("\n")
+        if first_newline >= 0:
+            candidate = candidate[first_newline + 1 : -3].strip()
+    try:
+        parsed = json.loads(candidate)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            "The provider did not return valid JSON "
+            f"(line {exc.lineno}, column {exc.colno})."
+        ) from None
+    if output_format == "JSON object" and not isinstance(parsed, dict):
+        raise RuntimeError("The provider returned JSON, but it was not an object.")
+    if schema is not None:
+        jsonschema = require_module("jsonschema", "jsonschema>=4.22,<5")
+        validator_class = jsonschema.validators.validator_for(schema)
+        validator = validator_class(schema)
+        error = next(validator.iter_errors(parsed), None)
+        if error is not None:
+            path = _schema_path(error.absolute_path)
+            rule = str(error.validator or "schema")
+            raise RuntimeError(
+                f"Structured output failed local validation at {path} "
+                f"({rule} constraint)."
+            ) from None
+    return json.dumps(parsed, ensure_ascii=False, indent=2)
+
+
+def _structured_prompt(
+    system_prompt: str,
+    output_format: str,
+    schema: dict[str, Any] | None,
+) -> str:
+    if output_format == "Text":
+        return system_prompt
+    if output_format == "JSON object":
+        guidance = (
+            "Return only one valid JSON object. Do not wrap it in Markdown or "
+            "include commentary outside the JSON."
+        )
+    else:
+        guidance = (
+            "Return only JSON matching this schema exactly. Do not wrap it in "
+            "Markdown or include commentary outside the JSON.\nJSON Schema:\n"
+            f"{json.dumps(schema, ensure_ascii=False, separators=(',', ':'))}"
+        )
+    return f"{system_prompt.rstrip()}\n\n{guidance}".strip()
+
+
+def _schema_style(profile: ProviderProfile, requested: str) -> str:
+    if requested not in SCHEMA_API_STYLES:
+        raise ValueError(
+            f"schema_api_style must be one of {SCHEMA_API_STYLES}."
+        )
+    if requested == "Auto (provider native)":
+        return profile.schema_api_style
+    if not profile.custom_endpoint:
+        raise ValueError(
+            "schema_api_style overrides are available only for Custom / Local; "
+            "built-in providers use their verified native contract."
+        )
+    return {
+        "OpenAI JSON Schema": "openai",
+        "llama.cpp JSON Schema": "llama_cpp",
+        "JSON object + local validation": "json_object",
+    }[requested]
+
+
+def _chat_response_format(
+    output_format: str,
+    schema: dict[str, Any] | None,
+    schema_style: str,
+) -> dict[str, Any] | None:
+    if output_format == "Text":
+        return None
+    if output_format == "JSON object" or schema_style == "json_object":
+        return {"type": "json_object"}
+    if schema_style == "llama_cpp":
+        return {"type": "json_schema", "schema": schema}
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "comfyui_output",
+            "strict": True,
+            "schema": schema,
+        },
+    }
+
+
 def _stream_responses(client: Any, request: dict[str, Any], sender) -> str:
     stream = client.responses.create(**request, stream=True)
     chunks: list[str] = []
@@ -634,14 +834,19 @@ def _stream_chat(client: Any, request: dict[str, Any], sender) -> str:
     return "".join(chunks).strip()
 
 
-def _anthropic_image_source(data_uri: str) -> dict[str, Any]:
+def _data_uri_parts(data_uri: str) -> tuple[str, str]:
     try:
         header, data = data_uri.split(",", 1)
         media_type = header.split(";", 1)[0].split(":", 1)[1]
     except (IndexError, ValueError):
-        raise ValueError("Invalid image data URI for Anthropic Messages.") from None
+        raise ValueError("Invalid image data URI.") from None
     if media_type not in {"image/jpeg", "image/png", "image/webp", "image/gif"}:
-        raise ValueError(f"Unsupported Anthropic image media type: {media_type}.")
+        raise ValueError(f"Unsupported image media type: {media_type}.")
+    return media_type, data
+
+
+def _anthropic_image_source(data_uri: str) -> dict[str, Any]:
+    media_type, data = _data_uri_parts(data_uri)
     return {
         "type": "base64",
         "media_type": media_type,
@@ -660,6 +865,137 @@ def _anthropic_response_text(payload: dict[str, Any]) -> str:
     ).strip()
 
 
+def _gemini_response_text(payload: dict[str, Any]) -> str:
+    candidates = payload.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        return ""
+    content = candidates[0].get("content")
+    if not isinstance(content, dict):
+        return ""
+    parts = content.get("parts")
+    if not isinstance(parts, list):
+        return ""
+    return "".join(
+        str(part.get("text", ""))
+        for part in parts
+        if isinstance(part, dict) and isinstance(part.get("text"), str)
+    )
+
+
+def _call_gemini_api(
+    *,
+    profile: ProviderProfile,
+    model: str,
+    api_key: str,
+    system_prompt: str,
+    prompt: str,
+    image_data: list[str],
+    timeout_seconds: float,
+    max_output_tokens: int,
+    stream_output: bool,
+    use_system_proxy: bool,
+    unique_id: str | None,
+    web_search: bool,
+    output_format: str,
+    output_schema: dict[str, Any] | None,
+) -> str:
+    """Use Gemini's native multimodal API for search and structured output."""
+
+    httpx = require_module("httpx", "httpx")
+    parts: list[dict[str, Any]] = [{"text": prompt}]
+    for data_uri in image_data:
+        media_type, data = _data_uri_parts(data_uri)
+        parts.append(
+            {
+                "inlineData": {
+                    "mimeType": media_type,
+                    "data": data,
+                }
+            }
+        )
+    generation_config: dict[str, Any] = {
+        "maxOutputTokens": int(max_output_tokens),
+    }
+    if output_format != "Text":
+        text_format: dict[str, Any] = {"mimeType": "application/json"}
+        if output_schema is not None:
+            text_format["schema"] = output_schema
+        generation_config["responseFormat"] = {"text": text_format}
+
+    request: dict[str, Any] = {
+        "systemInstruction": {"parts": [{"text": system_prompt}]},
+        "contents": [{"role": "user", "parts": parts}],
+        "generationConfig": generation_config,
+        "store": False,
+    }
+    if web_search:
+        request["tools"] = [{"google_search": {}}]
+
+    headers = {
+        "x-goog-api-key": api_key,
+        "content-type": "application/json",
+    }
+    sender = _progress_text_sender(unique_id) if stream_output else None
+    if sender is not None:
+        sender("Connecting securely…")
+    method = "streamGenerateContent" if stream_output else "generateContent"
+    url = (
+        "https://generativelanguage.googleapis.com/v1beta/models/"
+        f"{quote(model, safe='')}:{method}"
+    )
+    if stream_output:
+        url += "?alt=sse"
+
+    client = httpx.Client(
+        timeout=float(timeout_seconds),
+        follow_redirects=False,
+        trust_env=bool(use_system_proxy),
+    )
+    try:
+        if stream_output:
+            chunks: list[str] = []
+            with client.stream(
+                "POST",
+                url,
+                headers=headers,
+                json=request,
+            ) as response:
+                response.raise_for_status()
+                for line in response.iter_lines():
+                    if not line.startswith("data:"):
+                        continue
+                    raw = line[5:].strip()
+                    if not raw or raw == "[DONE]":
+                        continue
+                    try:
+                        delta = _gemini_response_text(json.loads(raw))
+                    except (json.JSONDecodeError, TypeError, ValueError):
+                        continue
+                    if not delta:
+                        continue
+                    chunks.append(delta)
+                    if sender is not None:
+                        sender("".join(chunks))
+            result = "".join(chunks).strip()
+        else:
+            response = client.post(
+                url,
+                headers=headers,
+                json=request,
+            )
+            response.raise_for_status()
+            result = _gemini_response_text(response.json()).strip()
+        if not result:
+            raise RuntimeError("Gemini returned an empty text response.")
+        if sender is not None:
+            sender(result)
+        return result
+    except Exception as exc:
+        raise safe_api_error(exc, profile, secret=api_key) from None
+    finally:
+        client.close()
+
+
 def _call_anthropic_api(
     *,
     profile: ProviderProfile,
@@ -674,6 +1010,9 @@ def _call_anthropic_api(
     stream_output: bool,
     use_system_proxy: bool,
     unique_id: str | None,
+    web_search: bool,
+    output_format: str,
+    output_schema: dict[str, Any] | None,
 ) -> str:
     """Use Anthropic's native Messages contract, including native vision."""
 
@@ -693,6 +1032,26 @@ def _call_anthropic_api(
         "max_tokens": int(max_output_tokens),
         "stream": bool(stream_output),
     }
+    if web_search:
+        request["tools"] = [
+            {
+                "type": "web_search_20260318",
+                "name": "web_search",
+                "allowed_callers": ["direct"],
+                "response_inclusion": "excluded",
+                "max_uses": 5,
+            }
+        ]
+    # Anthropic citation blocks and native structured output cannot be mixed.
+    # In that combination, JSON-object prompting plus local validation remains
+    # enabled without asking the API for an incompatible output_config.
+    if output_schema is not None and not web_search:
+        request["output_config"] = {
+            "format": {
+                "type": "json_schema",
+                "schema": output_schema,
+            }
+        }
     headers = {
         "x-api-key": api_key,
         "anthropic-version": "2023-06-01",
@@ -778,27 +1137,67 @@ def _call_hosted_api(
     stream_output: bool,
     use_system_proxy: bool,
     unique_id: str | None,
+    web_search: bool,
+    output_format: str,
+    output_schema: dict[str, Any] | None,
+    schema_api_style: str,
 ) -> str:
     if image_detail not in IMAGE_DETAILS:
         raise ValueError(f"image_detail must be one of {IMAGE_DETAILS}.")
     if reasoning_effort not in REASONING_EFFORTS:
         raise ValueError(f"reasoning_effort must be one of {REASONING_EFFORTS}.")
+    if web_search and profile.web_search == "none":
+        raise ValueError(
+            f"{profile.label} does not expose native web search through this API. "
+            "Choose OpenAI, Gemini, Anthropic, xAI, or route the model through "
+            "OpenRouter."
+        )
+    if profile.web_search == "gemini" and (
+        web_search or output_format != "Text"
+    ):
+        return validate_structured_output(
+            _call_gemini_api(
+                profile=profile,
+                model=model,
+                api_key=api_key,
+                system_prompt=system_prompt,
+                prompt=prompt,
+                image_data=image_data,
+                timeout_seconds=timeout_seconds,
+                max_output_tokens=max_output_tokens,
+                stream_output=stream_output,
+                use_system_proxy=use_system_proxy,
+                unique_id=unique_id,
+                web_search=web_search,
+                output_format=output_format,
+                output_schema=output_schema,
+            ),
+            output_format,
+            output_schema,
+        )
     if mode == "Anthropic Messages":
         if not endpoint:
             raise ValueError("Anthropic Messages requires its fixed API endpoint.")
-        return _call_anthropic_api(
-            profile=profile,
-            model=model,
-            endpoint=endpoint,
-            api_key=api_key,
-            system_prompt=system_prompt,
-            prompt=prompt,
-            image_data=image_data,
-            timeout_seconds=timeout_seconds,
-            max_output_tokens=max_output_tokens,
-            stream_output=stream_output,
-            use_system_proxy=use_system_proxy,
-            unique_id=unique_id,
+        return validate_structured_output(
+            _call_anthropic_api(
+                profile=profile,
+                model=model,
+                endpoint=endpoint,
+                api_key=api_key,
+                system_prompt=system_prompt,
+                prompt=prompt,
+                image_data=image_data,
+                timeout_seconds=timeout_seconds,
+                max_output_tokens=max_output_tokens,
+                stream_output=stream_output,
+                use_system_proxy=use_system_proxy,
+                unique_id=unique_id,
+                web_search=web_search,
+                output_format=output_format,
+                output_schema=output_schema,
+            ),
+            output_format,
+            output_schema,
         )
     openai = require_module("openai", "openai>=2,<3")
     client_kwargs: dict[str, Any] = {
@@ -845,6 +1244,19 @@ def _call_hosted_api(
                 request["store"] = False
                 if reasoning_effort != "none":
                     request["reasoning"] = {"effort": reasoning_effort}
+            if web_search:
+                request["tools"] = [{"type": "web_search"}]
+            if output_format == "JSON object":
+                request["text"] = {"format": {"type": "json_object"}}
+            elif output_schema is not None:
+                request["text"] = {
+                    "format": {
+                        "type": "json_schema",
+                        "name": "comfyui_output",
+                        "strict": True,
+                        "schema": output_schema,
+                    }
+                }
             if stream_output:
                 result = _stream_responses(client, request, sender)
             else:
@@ -877,6 +1289,15 @@ def _call_hosted_api(
             }
             if profile.supports_seed and int(seed):
                 request["seed"] = int(seed)
+            response_format = _chat_response_format(
+                output_format,
+                output_schema,
+                schema_api_style,
+            )
+            if response_format is not None:
+                request["response_format"] = response_format
+            if web_search and profile.web_search == "openrouter":
+                request["tools"] = [{"type": "openrouter:web_search"}]
             if stream_output:
                 result = _stream_chat(client, request, sender)
             else:
@@ -889,6 +1310,11 @@ def _call_hosted_api(
                 )
         if not result:
             raise RuntimeError("The provider returned an empty text response.")
+        result = validate_structured_output(
+            result,
+            output_format,
+            output_schema,
+        )
         if sender is not None:
             sender(result)
         return result
@@ -919,6 +1345,11 @@ def execute_hosted(
     use_system_proxy: bool,
     unique_id: str | None,
     image_data: list[str] | None = None,
+    image_detail: str = "auto",
+    web_search: bool = False,
+    output_format: str = "Text",
+    json_schema: str = "",
+    schema_api_style: str = "Auto (provider native)",
 ) -> tuple[str, str, ProviderProfile]:
     profile = provider_profile(model_name)
     model = (model_override or profile.model).strip()
@@ -937,6 +1368,14 @@ def execute_hosted(
         loopback=loopback,
     )
     mode = profile.api_mode if api_mode == "Auto" else api_mode
+    if (
+        api_mode == "Auto"
+        and profile.provider == "Groq"
+        and output_format != "Text"
+    ):
+        # Groq documents structured output on Chat Completions. Keep Responses
+        # as the fast default for ordinary text/vision generation.
+        mode = "Chat Completions"
     if mode not in {"Responses", "Chat Completions", "Anthropic Messages"}:
         raise ValueError("api_mode must be Auto, Responses, or Chat Completions.")
     if mode == "Responses" and not profile.responses:
@@ -950,6 +1389,17 @@ def execute_hosted(
         system_prompt,
         MAX_SYSTEM_PROMPT_CHARS,
     )
+    output_schema = parse_json_schema(output_format, json_schema)
+    safe_system_prompt = _structured_prompt(
+        safe_system_prompt,
+        output_format,
+        output_schema,
+    )
+    effective_schema_style = (
+        _schema_style(profile, schema_api_style)
+        if output_format == "JSON Schema"
+        else profile.schema_api_style
+    )
     result = _call_hosted_api(
         profile=profile,
         model=model,
@@ -959,7 +1409,7 @@ def execute_hosted(
         system_prompt=safe_system_prompt,
         prompt=safe_prompt,
         image_data=images,
-        image_detail=IMAGE_DETAILS[0],
+        image_detail=image_detail,
         timeout_seconds=max(1.0, min(1800.0, float(timeout_seconds))),
         max_output_tokens=max(1, min(131072, int(max_output_tokens))),
         reasoning_effort=reasoning_effort,
@@ -967,6 +1417,10 @@ def execute_hosted(
         stream_output=bool(stream_output),
         use_system_proxy=bool(use_system_proxy),
         unique_id=unique_id,
+        web_search=bool(web_search),
+        output_format=output_format,
+        output_schema=output_schema,
+        schema_api_style=effective_schema_style,
     )
     return result, model, profile
 
@@ -1057,6 +1511,47 @@ class PromptGenerateAPI:
                     "INT",
                     {"default": 4096, "min": 1, "max": 131072},
                 ),
+                "web_search": (
+                    "BOOLEAN",
+                    {
+                        "default": False,
+                        "tooltip": (
+                            "Enable the provider's native/server-side web search. "
+                            "Search calls may have additional cost and data terms."
+                        ),
+                    },
+                ),
+                "output_format": (
+                    OUTPUT_FORMATS,
+                    {
+                        "default": "Text",
+                        "tooltip": (
+                            "JSON modes are parsed and validated locally before "
+                            "the node succeeds."
+                        ),
+                    },
+                ),
+                "json_schema": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "",
+                        "tooltip": (
+                            "JSON Schema object used when output_format is "
+                            "JSON Schema."
+                        ),
+                    },
+                ),
+                "schema_api_style": (
+                    SCHEMA_API_STYLES,
+                    {
+                        "default": "Auto (provider native)",
+                        "tooltip": (
+                            "Custom / Local compatibility override. llama.cpp "
+                            "uses a different response_format schema shape."
+                        ),
+                    },
+                ),
                 "stream_output": ("BOOLEAN", {"default": True}),
                 "use_system_proxy": (
                     "BOOLEAN",
@@ -1095,6 +1590,10 @@ class PromptGenerateAPI:
         timeout_seconds=120.0,
         reasoning_effort="none",
         max_output_tokens=4096,
+        web_search=False,
+        output_format="Text",
+        json_schema="",
+        schema_api_style="Auto (provider native)",
         stream_output=True,
         use_system_proxy=False,
         unique_id=None,
@@ -1119,6 +1618,10 @@ class PromptGenerateAPI:
             stream_output=stream_output,
             use_system_proxy=use_system_proxy,
             unique_id=unique_id,
+            web_search=web_search,
+            output_format=output_format,
+            json_schema=json_schema,
+            schema_api_style=schema_api_style,
         )
         return (result,)
 
@@ -1200,6 +1703,41 @@ class HostedVLMAPI:
                     REASONING_EFFORTS,
                     {"default": "none"},
                 ),
+                "web_search": (
+                    "BOOLEAN",
+                    {
+                        "default": False,
+                        "tooltip": (
+                            "Enable native/server-side search where the selected "
+                            "provider supports it."
+                        ),
+                    },
+                ),
+                "output_format": (
+                    OUTPUT_FORMATS,
+                    {"default": "Text"},
+                ),
+                "json_schema": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "",
+                        "tooltip": (
+                            "For JSON Schema mode, including open-source VLMs "
+                            "served by llama.cpp, vLLM, or Ollama."
+                        ),
+                    },
+                ),
+                "schema_api_style": (
+                    SCHEMA_API_STYLES,
+                    {
+                        "default": "Auto (provider native)",
+                        "tooltip": (
+                            "Custom / Local only. Select llama.cpp for its direct "
+                            "schema response_format dialect."
+                        ),
+                    },
+                ),
                 "stream_output": ("BOOLEAN", {"default": True}),
                 "use_system_proxy": ("BOOLEAN", {"default": False}),
             },
@@ -1232,6 +1770,10 @@ class HostedVLMAPI:
         timeout_seconds=180.0,
         max_output_tokens=4096,
         reasoning_effort="none",
+        web_search=False,
+        output_format="Text",
+        json_schema="",
+        schema_api_style="Auto (provider native)",
         stream_output=True,
         use_system_proxy=False,
         unique_id=None,
@@ -1247,50 +1789,27 @@ class HostedVLMAPI:
             if images is not None
             else []
         )
-        model = (model_override or profile.model).strip()
-        if not model:
-            raise ValueError(f"A model_override is required for {profile.label}.")
-        if image_data and not profile.vision:
-            raise ValueError(f"{profile.label} does not accept image input.")
-
-        endpoint, loopback = resolve_endpoint(profile, base_url)
-        api_key = resolve_api_key(
-            profile,
-            credential_source,
-            loopback=loopback,
-        )
-        mode = profile.api_mode if api_mode == "Auto" else api_mode
-        if mode not in {"Responses", "Chat Completions", "Anthropic Messages"}:
-            raise ValueError(
-                "api_mode must be Auto, Responses, or Chat Completions."
-            )
-        if mode == "Responses" and not profile.responses:
-            raise ValueError(
-                f"{profile.provider} is configured for Chat Completions. Use Auto."
-            )
-        safe_prompt = _bounded_text("prompt", prompt, MAX_PROMPT_CHARS)
-        safe_system_prompt = _bounded_text(
-            "system_prompt",
-            system_prompt,
-            MAX_SYSTEM_PROMPT_CHARS,
-        )
-        result = _call_hosted_api(
-            profile=profile,
-            model=model,
-            endpoint=endpoint,
-            api_key=api_key,
-            mode=mode,
-            system_prompt=safe_system_prompt,
-            prompt=safe_prompt,
-            image_data=image_data,
-            image_detail=image_detail,
-            timeout_seconds=max(1.0, min(1800.0, float(timeout_seconds))),
-            max_output_tokens=max(1, min(131072, int(max_output_tokens))),
+        result, model, _profile = execute_hosted(
+            model_name=model_name,
+            credential_source=credential_source,
+            prompt=prompt,
+            system_prompt=system_prompt,
+            base_url=base_url,
+            model_override=model_override,
+            api_mode=api_mode,
+            timeout_seconds=timeout_seconds,
+            max_output_tokens=max_output_tokens,
             reasoning_effort=reasoning_effort,
             seed=0,
             stream_output=stream_output,
             use_system_proxy=use_system_proxy,
             unique_id=unique_id,
+            image_data=image_data,
+            image_detail=image_detail,
+            web_search=web_search,
+            output_format=output_format,
+            json_schema=json_schema,
+            schema_api_style=schema_api_style,
         )
         return result, model, len(image_data)
 

--- a/nodes/suggest.py
+++ b/nodes/suggest.py
@@ -8,7 +8,6 @@ producing stricter output.
 from __future__ import annotations
 
 import json
-import os
 import re
 from typing import Any, Literal, Optional
 
@@ -16,7 +15,7 @@ import folder_paths
 import torch
 from pydantic import BaseModel, Field
 
-from .prompts import system_msg_prompts, system_msg_simple
+from .prompts import system_msg_prompts
 from .runtime import (
     LlamaHandle,
     close_handle,
@@ -155,222 +154,6 @@ def _structured_chat(
     except json.JSONDecodeError as exc:
         raise RuntimeError(f"The model did not return valid JSON: {raw[:500]}") from exc
     return raw, parsed
-
-
-API_MODELS = [
-    "GPT-5.6 Terra",
-    "GPT-5.6 Sol",
-    "GPT-5.6 Luna",
-    "DeepSeek",
-    "Custom / OpenAI-compatible",
-    # Kept so saved workflows continue to deserialize without substitutions.
-    "ChatGPT-3.5",
-    "ChatGPT-4",
-    "gpt-3.5-turbo",
-    "gpt-3.5-turbo-0125",
-    "gpt-35-turbo",
-    "gpt-3.5-turbo-16k",
-    "gpt-3.5-turbo-16k-0613",
-    "gpt-4-0613",
-    "gpt-4-1106-preview",
-    "glm-4",
-]
-
-API_ROUTES = {
-    "GPT-5.6 Sol": ("gpt-5.6-sol", None, "Responses"),
-    "GPT-5.6 Terra": ("gpt-5.6-terra", None, "Responses"),
-    "GPT-5.6 Luna": ("gpt-5.6-luna", None, "Responses"),
-    "DeepSeek": ("deepseek-chat", "https://api.deepseek.com/v1", "Chat Completions"),
-    "ChatGPT-3.5": ("gpt-3.5-turbo", None, "Chat Completions"),
-    "ChatGPT-4": ("gpt-4", None, "Chat Completions"),
-    "gpt-35-turbo": ("gpt-35-turbo", None, "Chat Completions"),
-    "glm-4": ("glm-4", None, "Chat Completions"),
-}
-
-
-class PromptGenerateAPI:
-    def __init__(self):
-        self.session_history: list[dict[str, str]] = []
-
-    @classmethod
-    def INPUT_TYPES(cls):
-        return {
-            "required": {
-                "model_name": (API_MODELS, {"default": "GPT-5.6 Terra"}),
-                "chat_type": (
-                    "BOOLEAN",
-                    {
-                        "default": True,
-                        "label_on": "Prompt Generator",
-                        "label_off": "Simple Chat",
-                    },
-                ),
-                "api_key": (
-                    "STRING",
-                    {
-                        "default": "",
-                        "tooltip": (
-                            "Leave blank to use OPENAI_API_KEY, DEEPSEEK_API_KEY, "
-                            "or VLM_API_KEY."
-                        ),
-                    },
-                ),
-                "description": (
-                    "STRING",
-                    {"multiline": True, "default": ""},
-                ),
-                "question": (
-                    "STRING",
-                    {"multiline": True, "default": ""},
-                ),
-                "context_size": (
-                    "INT",
-                    {"default": 5, "min": 0, "max": 30, "step": 1},
-                ),
-                "seed": (
-                    "INT",
-                    {
-                        "default": 0,
-                        "min": 0,
-                        "max": 0xFFFFFFFFFFFFFFFF,
-                        "step": 1,
-                    },
-                ),
-            },
-            "optional": {
-                "base_url": (
-                    "STRING",
-                    {
-                        "default": "",
-                        "tooltip": (
-                            "OpenAI-compatible base URL, e.g. http://127.0.0.1:8000/v1."
-                        ),
-                    },
-                ),
-                "model_override": (
-                    "STRING",
-                    {
-                        "default": "",
-                        "tooltip": "Exact provider model ID. Overrides the picker.",
-                    },
-                ),
-                "api_mode": (
-                    ["Auto", "Responses", "Chat Completions"],
-                    {"default": "Auto"},
-                ),
-                "timeout_seconds": (
-                    "FLOAT",
-                    {"default": 120.0, "min": 1.0, "max": 1800.0},
-                ),
-                "reasoning_effort": (
-                    ["none", "low", "medium", "high", "xhigh", "max"],
-                    {"default": "none"},
-                ),
-            },
-        }
-
-    RETURN_TYPES = ("STRING",)
-    FUNCTION = "generate_prompt"
-    CATEGORY = "VLM Nodes/LLM"
-
-    def _route(
-        self, model_name, model_override, base_url, api_mode
-    ) -> tuple[str, str | None, str]:
-        route = API_ROUTES.get(model_name)
-        if route is None:
-            if model_name in API_MODELS and model_name not in {
-                "Custom / OpenAI-compatible"
-            }:
-                route = (model_name, None, "Chat Completions")
-            else:
-                route = ("", None, "Chat Completions")
-        model, route_url, route_mode = route
-        model = (model_override or model).strip()
-        if not model:
-            raise ValueError("A model ID is required for Custom / OpenAI-compatible.")
-        effective_url = (base_url or route_url or "").strip() or None
-        mode = route_mode if api_mode == "Auto" else api_mode
-        return model, effective_url, mode
-
-    def generate_prompt(
-        self,
-        model_name,
-        chat_type,
-        api_key,
-        description,
-        question,
-        context_size,
-        seed,
-        base_url="",
-        model_override="",
-        api_mode="Auto",
-        timeout_seconds=120.0,
-        reasoning_effort="none",
-    ):
-        openai = require_module("openai", "openai")
-        model, effective_url, mode = self._route(
-            model_name, model_override, base_url, api_mode
-        )
-        key = (
-            api_key.strip()
-            or (os.getenv("DEEPSEEK_API_KEY", "") if model_name == "DeepSeek" else "")
-            or os.getenv("VLM_API_KEY", "")
-            or os.getenv("OPENAI_API_KEY", "")
-        )
-        if not key:
-            raise ValueError(
-                "No API key was supplied. Set OPENAI_API_KEY, "
-                "DEEPSEEK_API_KEY, or VLM_API_KEY, or enter the key in the node."
-            )
-
-        client_kwargs: dict[str, Any] = {
-            "api_key": key,
-            "timeout": float(timeout_seconds),
-            "max_retries": 2,
-        }
-        if effective_url:
-            client_kwargs["base_url"] = effective_url
-        client = openai.OpenAI(**client_kwargs)
-
-        system = system_msg_prompts if chat_type else system_msg_simple
-        user_message = (
-            f"Description:\n{description.strip()}\n\n"
-            f"Optional question:\n{question.strip()}"
-        ).strip()
-        history_limit = max(0, int(context_size)) * 2
-        history = self.session_history[-history_limit:] if history_limit else []
-
-        if mode == "Responses":
-            response = client.responses.create(
-                model=model,
-                instructions=system,
-                input=history + [{"role": "user", "content": user_message}],
-                reasoning={"effort": reasoning_effort},
-            )
-            result = response.output_text
-        else:
-            messages = (
-                [{"role": "system", "content": system}]
-                + history
-                + [{"role": "user", "content": user_message}]
-            )
-            request: dict[str, Any] = {
-                "model": model,
-                "messages": messages,
-                "seed": int(seed),
-            }
-            if model.startswith("gpt-5.6"):
-                request["reasoning_effort"] = reasoning_effort
-            completion = client.chat.completions.create(**request)
-            result = completion.choices[0].message.content or ""
-
-        self.session_history.extend(
-            [
-                {"role": "user", "content": user_message},
-                {"role": "assistant", "content": result},
-            ]
-        )
-        return (result,)
 
 
 class LLMLoader:
@@ -1206,7 +989,6 @@ NODE_CLASS_MAPPINGS = {
     "KeywordExtraction": KeywordExtraction,
     "LLavaPromptGenerator": LLavaPromptGenerator,
     "Suggester": Suggester,
-    "PromptGenerateAPI": PromptGenerateAPI,
     "CreativeArtPromptGenerator": CreativeArtPromptGenerator,
     "ChatMusician": ChatMusician,
     "StructuredOutput": StructuredOutput,
@@ -1221,7 +1003,6 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "KeywordExtraction": "Structured Keyword Extraction",
     "LLavaPromptGenerator": "Structured Prompt Generator",
     "Suggester": "Prompt Suggester",
-    "PromptGenerateAPI": "OpenAI-Compatible Prompt API",
     "CreativeArtPromptGenerator": "Creative Art Prompt Generator",
     "ChatMusician": "Chat Musician",
     "StructuredOutput": "Structured Output",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "einops>=0.8,<1",
   "huggingface-hub>=1.5,<2",
   "httpx>=0.27,<1",
+  "jsonschema>=4.22,<5",
   "openai>=2,<3",
   "pydantic>=2.7,<3",
   "qwen-vl-utils>=0.0.14",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "comfyui_vlm_nodes"
-version = "3.0.0"
+version = "3.1.0"
 description = "Production-ready local and API vision-language nodes for ComfyUI"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -12,7 +12,8 @@ dependencies = [
   "diffusers>=0.34,<1",
   "einops>=0.8,<1",
   "huggingface-hub>=1.5,<2",
-  "openai>=1.30,<3",
+  "httpx>=0.27,<1",
+  "openai>=2,<3",
   "pydantic>=2.7,<3",
   "qwen-vl-utils>=0.0.14",
   "safetensors>=0.4.3",
@@ -69,6 +70,7 @@ comfyui_vlm_nodes = "."
 [tool.setuptools.package-data]
 comfyui_vlm_nodes = [
   "*.json",
+  "SECURITY.md",
   "requirements*.txt",
 ]
 "comfyui_vlm_nodes.web.js" = ["*.js"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ diffusers>=0.34,<1
 einops>=0.8,<1
 huggingface-hub>=1.5,<2
 httpx>=0.27,<1
+jsonschema>=4.22,<5
 openai>=2,<3
 pydantic>=2.7,<3
 qwen-vl-utils>=0.0.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ bitsandbytes>=0.50,<1; (sys_platform == "linux" and platform_machine == "x86_64"
 diffusers>=0.34,<1
 einops>=0.8,<1
 huggingface-hub>=1.5,<2
-openai>=1.30,<3
+httpx>=0.27,<1
+openai>=2,<3
 pydantic>=2.7,<3
 qwen-vl-utils>=0.0.14
 safetensors>=0.4.3

--- a/tests/test_hosted_api.py
+++ b/tests/test_hosted_api.py
@@ -1,0 +1,376 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from ComfyUI_VLM_nodes.nodes import hosted_api
+
+
+class FakeHttpClient:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class FakeResponses:
+    def __init__(self, calls, failure=None):
+        self.calls = calls
+        self.failure = failure
+
+    def create(self, **kwargs):
+        self.calls.append(("responses", kwargs))
+        if self.failure is not None:
+            raise self.failure
+        return SimpleNamespace(output_text="secure response")
+
+
+class FakeChatCompletions:
+    def __init__(self, calls, failure=None):
+        self.calls = calls
+        self.failure = failure
+
+    def create(self, **kwargs):
+        self.calls.append(("chat", kwargs))
+        if self.failure is not None:
+            raise self.failure
+        message = SimpleNamespace(content="secure response")
+        return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+def fake_openai_module(calls, failure=None):
+    class FakeOpenAI:
+        def __init__(self, **kwargs):
+            calls.append(("client", kwargs))
+            self.responses = FakeResponses(calls, failure=failure)
+            self.chat = SimpleNamespace(
+                completions=FakeChatCompletions(calls, failure=failure)
+            )
+
+        def close(self):
+            calls.append(("close", {}))
+
+    return SimpleNamespace(
+        OpenAI=FakeOpenAI,
+        DefaultHttpxClient=FakeHttpClient,
+    )
+
+
+def test_api_schemas_never_accept_plaintext_keys():
+    for node_class in (hosted_api.PromptGenerateAPI, hosted_api.HostedVLMAPI):
+        schema = node_class.INPUT_TYPES()
+        all_inputs = {
+            **schema.get("required", {}),
+            **schema.get("optional", {}),
+            **schema.get("hidden", {}),
+        }
+        assert "api_key" not in all_inputs
+        assert "credential_source" in all_inputs
+        assert "STRING" not in repr(all_inputs["credential_source"][0])
+
+
+def test_provider_catalog_uses_current_bound_credentials_and_endpoints():
+    assert len(hosted_api.PROVIDER_PROFILES) >= 18
+    expected = {
+        "OpenAI": "OPENAI_API_KEY",
+        "Google Gemini": "GEMINI_API_KEY",
+        "Anthropic": "ANTHROPIC_API_KEY",
+        "xAI": "XAI_API_KEY",
+        "DeepSeek": "DEEPSEEK_API_KEY",
+        "Groq": "GROQ_API_KEY",
+        "Mistral": "MISTRAL_API_KEY",
+        "Together AI": "TOGETHER_API_KEY",
+        "OpenRouter": "OPENROUTER_API_KEY",
+        "Custom / Local": "CUSTOM_API_KEY",
+    }
+    providers = {
+        profile.provider: profile.api_key_env
+        for profile in hosted_api.PROVIDER_PROFILES.values()
+    }
+    assert expected.items() <= providers.items()
+    for profile in hosted_api.PROVIDER_PROFILES.values():
+        if profile.base_url is not None:
+            assert profile.base_url.startswith("https://")
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://example.com/v1",
+        "ftp://127.0.0.1/v1",
+        "https://user:secret@example.com/v1",
+        "https://example.com/v1?api_key=secret",
+        "not-a-url",
+    ],
+)
+def test_custom_endpoint_rejects_unsafe_urls(url):
+    with pytest.raises(ValueError):
+        hosted_api.validate_custom_base_url(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1:8000/v1",
+        "http://[::1]:11434/v1",
+        "http://localhost:1234/v1",
+        "https://example.com/v1/",
+    ],
+)
+def test_custom_endpoint_accepts_https_or_loopback(url):
+    normalized, loopback = hosted_api.validate_custom_base_url(url)
+    assert normalized.startswith(("http://", "https://"))
+    assert loopback is (url.startswith("http://"))
+
+
+def test_built_in_key_cannot_be_redirected(monkeypatch):
+    profile = hosted_api.provider_profile("OpenAI — GPT-5.6 Terra")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-real-secret-value")
+    with pytest.raises(ValueError, match="pinned to official hosts"):
+        hosted_api.resolve_endpoint(profile, "https://attacker.example/v1")
+
+
+def test_legacy_plaintext_value_is_rejected_without_echo(monkeypatch):
+    profile = hosted_api.provider_profile("OpenAI — GPT-5.6 Terra")
+    secret = "sk-legacy-plaintext-that-must-not-appear"
+    with pytest.raises(ValueError) as captured:
+        hosted_api.resolve_api_key(profile, secret, loopback=False)
+    assert secret not in str(captured.value)
+    assert "legacy plaintext API key was removed" in str(captured.value)
+
+
+def test_redaction_removes_exact_encoded_and_header_credentials():
+    secret = "sk-ant-example-SECRET_123456789"
+    message = (
+        f"Authorization: Bearer {secret}; api_key={secret}; "
+        f"url=https://user:{secret}@example.com; encoded={secret}"
+    )
+    redacted = hosted_api.redact_sensitive(message, (secret,))
+    assert secret not in redacted
+    assert "Bearer" not in redacted
+    assert "[REDACTED]" in redacted
+
+
+def test_responses_call_is_stateless_private_and_provider_bound(monkeypatch):
+    calls = []
+    secret = "sk-openai-provider-bound-secret"
+    monkeypatch.setenv("OPENAI_API_KEY", secret)
+    monkeypatch.setattr(
+        hosted_api,
+        "require_module",
+        lambda *_args: fake_openai_module(calls),
+    )
+
+    node = hosted_api.PromptGenerateAPI()
+    assert not hasattr(node, "session_history")
+    result = node.generate_prompt(
+        "OpenAI — GPT-5.6 Terra",
+        False,
+        hosted_api.PROVIDER_CREDENTIAL,
+        "A scene",
+        "Improve it",
+        0,
+        0,
+        stream_output=False,
+    )
+    assert result == ("secure response",)
+
+    client_kwargs = next(payload for kind, payload in calls if kind == "client")
+    assert client_kwargs["api_key"] == secret
+    assert "base_url" not in client_kwargs
+    assert client_kwargs["http_client"].kwargs["follow_redirects"] is False
+    assert client_kwargs["http_client"].kwargs["trust_env"] is False
+
+    request = next(payload for kind, payload in calls if kind == "responses")
+    assert request["model"] == "gpt-5.6-terra"
+    assert request["store"] is False
+    assert "previous_response_id" not in request
+    assert "metadata" not in request
+
+
+def test_responses_stream_collects_deltas_and_closes():
+    class Stream(list):
+        closed = False
+
+        def close(self):
+            self.closed = True
+
+    stream = Stream(
+        [
+            SimpleNamespace(type="response.created"),
+            SimpleNamespace(type="response.output_text.delta", delta="hello "),
+            SimpleNamespace(type="response.output_text.delta", delta="world"),
+        ]
+    )
+    client = SimpleNamespace(
+        responses=SimpleNamespace(create=lambda **kwargs: stream)
+    )
+    assert hosted_api._stream_responses(client, {"model": "test"}, None) == (
+        "hello world"
+    )
+    assert stream.closed is True
+
+
+def test_chat_stream_collects_deltas_and_closes():
+    class Stream(list):
+        closed = False
+
+        def close(self):
+            self.closed = True
+
+    stream = Stream(
+        [
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(delta=SimpleNamespace(content="frame "))
+                ]
+            ),
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(delta=SimpleNamespace(content="ready"))
+                ]
+            ),
+        ]
+    )
+    client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=lambda **kwargs: stream)
+        )
+    )
+    assert hosted_api._stream_chat(client, {"model": "test"}, None) == (
+        "frame ready"
+    )
+    assert stream.closed is True
+
+
+def test_provider_failure_never_echoes_api_key(monkeypatch):
+    calls = []
+    secret = "sk-secret-reflected-by-provider-123456"
+    failure = RuntimeError(f"Authorization: Bearer {secret} api_key={secret}")
+    monkeypatch.setenv("OPENAI_API_KEY", secret)
+    monkeypatch.setattr(
+        hosted_api,
+        "require_module",
+        lambda *_args: fake_openai_module(calls, failure=failure),
+    )
+
+    with pytest.raises(RuntimeError) as captured:
+        hosted_api.PromptGenerateAPI().generate_prompt(
+            "OpenAI — GPT-5.6 Terra",
+            False,
+            hosted_api.PROVIDER_CREDENTIAL,
+            "hello",
+            "",
+            0,
+            0,
+            stream_output=False,
+        )
+    assert secret not in str(captured.value)
+    assert "[REDACTED]" in str(captured.value)
+
+
+def test_anthropic_uses_native_messages_and_keeps_key_out_of_body(monkeypatch):
+    calls = []
+    secret = "sk-ant-native-secret"
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "content": [
+                    {"type": "text", "text": "native Anthropic response"}
+                ]
+            }
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            calls.append(("client", kwargs))
+
+        def post(self, url, **kwargs):
+            calls.append(("post", {"url": url, **kwargs}))
+            return FakeResponse()
+
+        def close(self):
+            calls.append(("close", {}))
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", secret)
+    monkeypatch.setattr(
+        hosted_api,
+        "require_module",
+        lambda import_name, *_args: (
+            SimpleNamespace(Client=FakeClient)
+            if import_name == "httpx"
+            else pytest.fail(f"Unexpected module request: {import_name}")
+        ),
+    )
+    result = hosted_api.HostedVLMAPI().analyze(
+        "Anthropic — Claude Sonnet 5",
+        hosted_api.PROVIDER_CREDENTIAL,
+        "Read this image.",
+        "Be concise.",
+        1,
+        512,
+        80,
+        "auto",
+        images=torch.rand((1, 48, 64, 3)),
+        stream_output=False,
+    )
+    assert result == (
+        "native Anthropic response",
+        "claude-sonnet-5",
+        1,
+    )
+    request = next(payload for kind, payload in calls if kind == "post")
+    assert request["url"] == "https://api.anthropic.com/v1/messages"
+    assert request["headers"]["x-api-key"] == secret
+    assert secret not in repr(request["json"])
+    content = request["json"]["messages"][0]["content"]
+    assert content[1]["type"] == "image"
+    assert content[1]["source"]["type"] == "base64"
+    assert request["json"]["stream"] is False
+
+
+def test_vlm_uniformly_samples_and_bounds_image_batch(monkeypatch):
+    calls = []
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-only")
+    monkeypatch.setattr(
+        hosted_api,
+        "require_module",
+        lambda *_args: fake_openai_module(calls),
+    )
+    images = torch.rand((10, 96, 128, 3), dtype=torch.float32)
+    result = hosted_api.HostedVLMAPI().analyze(
+        "OpenAI — GPT-5.6 Terra",
+        hosted_api.PROVIDER_CREDENTIAL,
+        "Compare the sampled frames.",
+        "Be precise.",
+        4,
+        768,
+        82,
+        "low",
+        images=images,
+        stream_output=False,
+    )
+    assert result == ("secure response", "gpt-5.6-terra", 4)
+    request = next(payload for kind, payload in calls if kind == "responses")
+    content = request["input"][0]["content"]
+    image_parts = [part for part in content if part["type"] == "input_image"]
+    assert len(image_parts) == 4
+    assert all(part["image_url"].startswith("data:image/jpeg;base64,") for part in image_parts)
+    assert all(part["detail"] == "low" for part in image_parts)
+
+
+def test_frontend_scrubs_legacy_key_before_graph_configuration():
+    web_root = Path(__file__).resolve().parents[1] / "web" / "js"
+    source = (
+        web_root / "apiSecurity.js"
+    ).read_text("utf-8")
+    assert "beforeConfigureGraph" in source
+    assert "delete values.api_key" in source
+    assert "CREDENTIAL_WIDGET_INDEX = 2" in source
+    view_text = (web_root / "viewText.js").read_text("utf-8")
+    assert '"PromptGenerateAPI"' in view_text
+    assert '"HostedVLMAPI"' in view_text

--- a/tests/test_hosted_api.py
+++ b/tests/test_hosted_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -15,37 +16,47 @@ class FakeHttpClient:
 
 
 class FakeResponses:
-    def __init__(self, calls, failure=None):
+    def __init__(self, calls, failure=None, response_text="secure response"):
         self.calls = calls
         self.failure = failure
+        self.response_text = response_text
 
     def create(self, **kwargs):
         self.calls.append(("responses", kwargs))
         if self.failure is not None:
             raise self.failure
-        return SimpleNamespace(output_text="secure response")
+        return SimpleNamespace(output_text=self.response_text)
 
 
 class FakeChatCompletions:
-    def __init__(self, calls, failure=None):
+    def __init__(self, calls, failure=None, response_text="secure response"):
         self.calls = calls
         self.failure = failure
+        self.response_text = response_text
 
     def create(self, **kwargs):
         self.calls.append(("chat", kwargs))
         if self.failure is not None:
             raise self.failure
-        message = SimpleNamespace(content="secure response")
+        message = SimpleNamespace(content=self.response_text)
         return SimpleNamespace(choices=[SimpleNamespace(message=message)])
 
 
-def fake_openai_module(calls, failure=None):
+def fake_openai_module(calls, failure=None, response_text="secure response"):
     class FakeOpenAI:
         def __init__(self, **kwargs):
             calls.append(("client", kwargs))
-            self.responses = FakeResponses(calls, failure=failure)
+            self.responses = FakeResponses(
+                calls,
+                failure=failure,
+                response_text=response_text,
+            )
             self.chat = SimpleNamespace(
-                completions=FakeChatCompletions(calls, failure=failure)
+                completions=FakeChatCompletions(
+                    calls,
+                    failure=failure,
+                    response_text=response_text,
+                )
             )
 
         def close(self):
@@ -68,6 +79,59 @@ def test_api_schemas_never_accept_plaintext_keys():
         assert "api_key" not in all_inputs
         assert "credential_source" in all_inputs
         assert "STRING" not in repr(all_inputs["credential_source"][0])
+        assert "web_search" in all_inputs
+        assert "output_format" in all_inputs
+        assert "json_schema" in all_inputs
+        assert "schema_api_style" in all_inputs
+
+
+def test_json_schema_parser_blocks_remote_refs_and_bounds_input():
+    for keyword in ("$ref", "$dynamicRef", "$recursiveRef"):
+        with pytest.raises(ValueError, match="only local fragment"):
+            hosted_api.parse_json_schema(
+                "JSON Schema",
+                json.dumps(
+                    {
+                        "type": "object",
+                        "properties": {
+                            "payload": {
+                                keyword: "https://attacker.example/schema.json"
+                            }
+                        },
+                    }
+                ),
+            )
+    with pytest.raises(ValueError, match="64,000"):
+        hosted_api.parse_json_schema("JSON Schema", "x" * 64_001)
+
+
+def test_local_structured_output_validation_is_strict_and_normalized():
+    schema_text = json.dumps(
+        {
+            "type": "object",
+            "properties": {"count": {"type": "integer"}},
+            "required": ["count"],
+            "additionalProperties": False,
+        }
+    )
+    schema = hosted_api.parse_json_schema("JSON Schema", schema_text)
+    assert hosted_api.validate_structured_output(
+        '```json\n{"count": 2}\n```',
+        "JSON Schema",
+        schema,
+    ) == '{\n  "count": 2\n}'
+    with pytest.raises(RuntimeError, match=r"\$\.count \(type constraint\)"):
+        hosted_api.validate_structured_output(
+            '{"count": "two"}',
+            "JSON Schema",
+            schema,
+        )
+    with pytest.raises(RuntimeError, match="valid JSON"):
+        hosted_api.validate_structured_output(
+            '{"count":',
+            "JSON Schema",
+            schema,
+        )
 
 
 def test_provider_catalog_uses_current_bound_credentials_and_endpoints():
@@ -187,6 +251,66 @@ def test_responses_call_is_stateless_private_and_provider_bound(monkeypatch):
     assert request["store"] is False
     assert "previous_response_id" not in request
     assert "metadata" not in request
+
+
+def test_openai_combines_web_search_structured_output_and_stream_contract(
+    monkeypatch,
+):
+    calls = []
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-structured-search")
+    monkeypatch.setattr(
+        hosted_api,
+        "require_module",
+        lambda import_name, *_args: (
+            fake_openai_module(calls, response_text='{"answer":"grounded"}')
+            if import_name == "openai"
+            else __import__(import_name)
+        ),
+    )
+    schema = json.dumps(
+        {
+            "type": "object",
+            "properties": {"answer": {"type": "string"}},
+            "required": ["answer"],
+            "additionalProperties": False,
+        }
+    )
+    result = hosted_api.PromptGenerateAPI().generate_prompt(
+        "OpenAI — GPT-5.6 Sol",
+        False,
+        hosted_api.PROVIDER_CREDENTIAL,
+        "Find a current fact",
+        "",
+        0,
+        0,
+        web_search=True,
+        output_format="JSON Schema",
+        json_schema=schema,
+        stream_output=False,
+    )
+    assert result == ('{\n  "answer": "grounded"\n}',)
+    request = next(payload for kind, payload in calls if kind == "responses")
+    assert request["tools"] == [{"type": "web_search"}]
+    assert request["text"]["format"]["type"] == "json_schema"
+    assert request["text"]["format"]["strict"] is True
+    assert request["text"]["format"]["schema"]["required"] == ["answer"]
+    assert "JSON Schema:" in request["instructions"]
+
+
+def test_unsupported_web_search_fails_before_network(monkeypatch):
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "deepseek-test-secret")
+    with pytest.raises(ValueError, match="does not expose native web search"):
+        hosted_api.PromptGenerateAPI().generate_prompt(
+            "DeepSeek — V4 Flash",
+            False,
+            hosted_api.PROVIDER_CREDENTIAL,
+            "Search now",
+            "",
+            0,
+            0,
+            web_search=True,
+            stream_output=False,
+        )
 
 
 def test_responses_stream_collects_deltas_and_closes():
@@ -333,6 +457,278 @@ def test_anthropic_uses_native_messages_and_keeps_key_out_of_body(monkeypatch):
     assert request["json"]["stream"] is False
 
 
+def test_anthropic_native_stream_collects_text_deltas(monkeypatch):
+    class FakeStreamResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def raise_for_status(self):
+            return None
+
+        def iter_lines(self):
+            yield 'event: content_block_delta'
+            yield (
+                'data: {"type":"content_block_delta","delta":'
+                '{"type":"text_delta","text":"hello "}}'
+            )
+            yield (
+                'data: {"type":"content_block_delta","delta":'
+                '{"type":"text_delta","text":"world"}}'
+            )
+
+    class FakeClient:
+        def __init__(self, **_kwargs):
+            pass
+
+        def stream(self, *_args, **_kwargs):
+            return FakeStreamResponse()
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(
+        hosted_api,
+        "require_module",
+        lambda import_name, *_args: (
+            SimpleNamespace(Client=FakeClient)
+            if import_name == "httpx"
+            else __import__(import_name)
+        ),
+    )
+    profile = hosted_api.provider_profile("Anthropic — Claude Sonnet 5")
+    result = hosted_api._call_anthropic_api(
+        profile=profile,
+        model=profile.model,
+        endpoint=profile.base_url,
+        api_key="sk-ant-stream",
+        system_prompt="Be concise.",
+        prompt="Hello",
+        image_data=[],
+        timeout_seconds=30,
+        max_output_tokens=100,
+        stream_output=True,
+        use_system_proxy=False,
+        unique_id=None,
+        web_search=False,
+        output_format="Text",
+        output_schema=None,
+    )
+    assert result == "hello world"
+
+
+def test_anthropic_native_search_and_structured_contracts(monkeypatch):
+    calls = []
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"content": [{"type": "text", "text": '{"answer":"yes"}'}]}
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            calls.append(("client", kwargs))
+
+        def post(self, url, **kwargs):
+            calls.append(("post", {"url": url, **kwargs}))
+            return FakeResponse()
+
+        def close(self):
+            return None
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-contract")
+    monkeypatch.setattr(
+        hosted_api,
+        "require_module",
+        lambda import_name, *_args: (
+            SimpleNamespace(Client=FakeClient)
+            if import_name == "httpx"
+            else __import__(import_name)
+        ),
+    )
+    schema = (
+        '{"type":"object","properties":{"answer":{"type":"string"}},'
+        '"required":["answer"],"additionalProperties":false}'
+    )
+
+    result = hosted_api.PromptGenerateAPI().generate_prompt(
+        "Anthropic — Claude Sonnet 5",
+        False,
+        hosted_api.PROVIDER_CREDENTIAL,
+        "Return a value",
+        "",
+        0,
+        0,
+        output_format="JSON Schema",
+        json_schema=schema,
+        stream_output=False,
+    )
+    assert json.loads(result[0]) == {"answer": "yes"}
+    structured = next(payload for kind, payload in calls if kind == "post")
+    assert structured["json"]["output_config"]["format"]["type"] == "json_schema"
+
+    calls.clear()
+    hosted_api.PromptGenerateAPI().generate_prompt(
+        "Anthropic — Claude Sonnet 5",
+        False,
+        hosted_api.PROVIDER_CREDENTIAL,
+        "Search the web",
+        "",
+        0,
+        0,
+        web_search=True,
+        output_format="JSON Schema",
+        json_schema=schema,
+        stream_output=False,
+    )
+    searched = next(payload for kind, payload in calls if kind == "post")
+    assert searched["json"]["tools"][0]["type"] == "web_search_20260318"
+    assert searched["json"]["tools"][0]["allowed_callers"] == ["direct"]
+    assert "output_config" not in searched["json"]
+
+
+def test_gemini_native_search_vision_and_schema_contract(monkeypatch):
+    calls = []
+    secret = "gemini-provider-secret"
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [{"text": '{"objects":["tree"]}'}]
+                        }
+                    }
+                ]
+            }
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            calls.append(("client", kwargs))
+
+        def post(self, url, **kwargs):
+            calls.append(("post", {"url": url, **kwargs}))
+            return FakeResponse()
+
+        def close(self):
+            return None
+
+    monkeypatch.setenv("GEMINI_API_KEY", secret)
+    monkeypatch.setattr(
+        hosted_api,
+        "require_module",
+        lambda import_name, *_args: (
+            SimpleNamespace(Client=FakeClient)
+            if import_name == "httpx"
+            else __import__(import_name)
+        ),
+    )
+    schema = (
+        '{"type":"object","properties":{"objects":{"type":"array",'
+        '"items":{"type":"string"}}},"required":["objects"]}'
+    )
+    result = hosted_api.HostedVLMAPI().analyze(
+        "Google — Gemini 3.6 Flash",
+        hosted_api.PROVIDER_CREDENTIAL,
+        "Identify objects using current context.",
+        "Be precise.",
+        1,
+        512,
+        80,
+        "auto",
+        images=torch.rand((1, 32, 48, 3)),
+        web_search=True,
+        output_format="JSON Schema",
+        json_schema=schema,
+        stream_output=False,
+    )
+    assert json.loads(result[0]) == {"objects": ["tree"]}
+    request = next(payload for kind, payload in calls if kind == "post")
+    assert request["url"].endswith(
+        "/models/gemini-3.6-flash:generateContent"
+    )
+    assert request["headers"]["x-goog-api-key"] == secret
+    assert secret not in repr(request["json"])
+    assert request["json"]["tools"] == [{"google_search": {}}]
+    assert (
+        request["json"]["generationConfig"]["responseFormat"]["text"]["schema"][
+            "required"
+        ]
+        == ["objects"]
+    )
+    inline = request["json"]["contents"][0]["parts"][1]["inlineData"]
+    assert inline["mimeType"] == "image/jpeg"
+    assert inline["data"]
+
+
+def test_gemini_native_stream_collects_sse_deltas(monkeypatch):
+    class FakeStreamResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def raise_for_status(self):
+            return None
+
+        def iter_lines(self):
+            yield (
+                'data: {"candidates":[{"content":{"parts":'
+                '[{"text":"frame "}]}}]}'
+            )
+            yield (
+                'data: {"candidates":[{"content":{"parts":'
+                '[{"text":"ready"}]}}]}'
+            )
+
+    class FakeClient:
+        def __init__(self, **_kwargs):
+            pass
+
+        def stream(self, *_args, **_kwargs):
+            return FakeStreamResponse()
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(
+        hosted_api,
+        "require_module",
+        lambda import_name, *_args: (
+            SimpleNamespace(Client=FakeClient)
+            if import_name == "httpx"
+            else __import__(import_name)
+        ),
+    )
+    profile = hosted_api.provider_profile("Google — Gemini 3.6 Flash")
+    result = hosted_api._call_gemini_api(
+        profile=profile,
+        model=profile.model,
+        api_key="gemini-stream",
+        system_prompt="Be concise.",
+        prompt="Describe.",
+        image_data=[],
+        timeout_seconds=30,
+        max_output_tokens=100,
+        stream_output=True,
+        use_system_proxy=False,
+        unique_id=None,
+        web_search=True,
+        output_format="Text",
+        output_schema=None,
+    )
+    assert result == "frame ready"
+
+
 def test_vlm_uniformly_samples_and_bounds_image_batch(monkeypatch):
     calls = []
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test-only")
@@ -361,6 +757,139 @@ def test_vlm_uniformly_samples_and_bounds_image_batch(monkeypatch):
     assert len(image_parts) == 4
     assert all(part["image_url"].startswith("data:image/jpeg;base64,") for part in image_parts)
     assert all(part["detail"] == "low" for part in image_parts)
+
+
+def test_open_source_vlm_llama_cpp_schema_dialect_and_local_validation(
+    monkeypatch,
+):
+    calls = []
+    monkeypatch.setattr(
+        hosted_api,
+        "require_module",
+        lambda import_name, *_args: (
+            fake_openai_module(calls, response_text='{"objects":["cat"]}')
+            if import_name == "openai"
+            else __import__(import_name)
+        ),
+    )
+    schema = json.dumps(
+        {
+            "type": "object",
+            "properties": {
+                "objects": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                }
+            },
+            "required": ["objects"],
+            "additionalProperties": False,
+        }
+    )
+    result = hosted_api.HostedVLMAPI().analyze(
+        "Custom / Local — OpenAI compatible",
+        hosted_api.LOCAL_NO_KEY,
+        "List visible objects.",
+        "Be precise.",
+        1,
+        512,
+        80,
+        "auto",
+        images=torch.rand((1, 32, 48, 3)),
+        base_url="http://127.0.0.1:8080/v1",
+        model_override="local-vlm",
+        output_format="JSON Schema",
+        json_schema=schema,
+        schema_api_style="llama.cpp JSON Schema",
+        stream_output=False,
+    )
+    assert result == (
+        '{\n  "objects": [\n    "cat"\n  ]\n}',
+        "local-vlm",
+        1,
+    )
+    request = next(payload for kind, payload in calls if kind == "chat")
+    assert request["response_format"] == {
+        "type": "json_schema",
+        "schema": json.loads(schema),
+    }
+    image = request["messages"][1]["content"][1]
+    assert image["type"] == "image_url"
+    assert image["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+
+def test_custom_openai_schema_style_uses_standard_wrapper(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        hosted_api,
+        "require_module",
+        lambda import_name, *_args: (
+            fake_openai_module(calls, response_text='{"ok":true}')
+            if import_name == "openai"
+            else __import__(import_name)
+        ),
+    )
+    schema = '{"type":"object","properties":{"ok":{"type":"boolean"}},"required":["ok"]}'
+    result, _, _ = hosted_api.execute_hosted(
+        model_name="Custom / Local — OpenAI compatible",
+        credential_source=hosted_api.LOCAL_NO_KEY,
+        prompt="Return status.",
+        system_prompt="Be exact.",
+        base_url="http://localhost:8000/v1",
+        model_override="local",
+        api_mode="Chat Completions",
+        timeout_seconds=30,
+        max_output_tokens=100,
+        reasoning_effort="none",
+        seed=0,
+        stream_output=False,
+        use_system_proxy=False,
+        unique_id=None,
+        output_format="JSON Schema",
+        json_schema=schema,
+    )
+    assert json.loads(result) == {"ok": True}
+    request = next(payload for kind, payload in calls if kind == "chat")
+    assert request["response_format"]["json_schema"]["strict"] is True
+    assert request["response_format"]["json_schema"]["schema"]["required"] == [
+        "ok"
+    ]
+
+
+def test_groq_auto_uses_documented_chat_route_for_structured_output(monkeypatch):
+    calls = []
+    monkeypatch.setenv("GROQ_API_KEY", "gsk-test-structured")
+    monkeypatch.setattr(
+        hosted_api,
+        "require_module",
+        lambda import_name, *_args: (
+            fake_openai_module(calls, response_text='{"ok":true}')
+            if import_name == "openai"
+            else __import__(import_name)
+        ),
+    )
+    hosted_api.execute_hosted(
+        model_name="Groq — GPT-OSS 20B",
+        credential_source=hosted_api.PROVIDER_CREDENTIAL,
+        prompt="Return status.",
+        system_prompt="Be exact.",
+        base_url="",
+        model_override="",
+        api_mode="Auto",
+        timeout_seconds=30,
+        max_output_tokens=100,
+        reasoning_effort="none",
+        seed=0,
+        stream_output=False,
+        use_system_proxy=False,
+        unique_id=None,
+        output_format="JSON Schema",
+        json_schema=(
+            '{"type":"object","properties":{"ok":{"type":"boolean"}},'
+            '"required":["ok"],"additionalProperties":false}'
+        ),
+    )
+    assert any(kind == "chat" for kind, _payload in calls)
+    assert not any(kind == "responses" for kind, _payload in calls)
 
 
 def test_frontend_scrubs_legacy_key_before_graph_configuration():

--- a/web/js/apiSecurity.js
+++ b/web/js/apiSecurity.js
@@ -1,0 +1,62 @@
+import { app } from "../../../scripts/app.js";
+
+const LLM_NODE = "PromptGenerateAPI";
+const SAFE_SOURCE = "Provider environment variable";
+const NO_KEY_SOURCE = "No key (loopback custom endpoint only)";
+const SAFE_SOURCES = new Set([SAFE_SOURCE, NO_KEY_SOURCE]);
+const CREDENTIAL_WIDGET_INDEX = 2;
+
+function visitGraphNodes(graphData, callback) {
+    for (const node of graphData?.nodes ?? []) {
+        callback(node);
+    }
+    for (const subgraph of graphData?.definitions?.subgraphs ?? []) {
+        visitGraphNodes(subgraph, callback);
+    }
+}
+
+function scrubSerializedNode(node) {
+    if (node?.type !== LLM_NODE) {
+        return;
+    }
+    const values = node.widgets_values;
+    if (Array.isArray(values)) {
+        const saved = values[CREDENTIAL_WIDGET_INDEX];
+        if (!SAFE_SOURCES.has(saved)) {
+            values[CREDENTIAL_WIDGET_INDEX] = SAFE_SOURCE;
+        }
+        return;
+    }
+    if (values && typeof values === "object") {
+        // Some frontend versions serialize widgets by name.
+        delete values.api_key;
+        if (!SAFE_SOURCES.has(values.credential_source)) {
+            values.credential_source = SAFE_SOURCE;
+        }
+    }
+}
+
+function enforceLiveWidget(node) {
+    if (node?.type !== LLM_NODE) {
+        return;
+    }
+    const widget = node.widgets?.find(
+        (item) => item.name === "credential_source",
+    );
+    if (widget && !SAFE_SOURCES.has(widget.value)) {
+        widget.value = SAFE_SOURCE;
+        widget.callback?.(SAFE_SOURCE);
+    }
+}
+
+app.registerExtension({
+    name: "gokayfem.vlm.api-credential-security",
+    async beforeConfigureGraph(graphData) {
+        // Runs on the cloned workflow before LiteGraph creates any widgets, so a
+        // legacy key never reaches a DOM input or the active graph.
+        visitGraphNodes(graphData, scrubSerializedNode);
+    },
+    loadedGraphNode(node) {
+        enforceLiveWidget(node);
+    },
+});

--- a/web/js/viewText.js
+++ b/web/js/viewText.js
@@ -3,7 +3,11 @@ import { api } from "../../../scripts/api.js";
 
 const OUTPUT_NAME = "output_text";
 const VIEW_TEXT_NODE = "ViewText";
-const MODERN_VLM_NODE = "ModernVLM";
+const STREAMING_SOURCE_NODES = new Set([
+    "ModernVLM",
+    "PromptGenerateAPI",
+    "HostedVLMAPI",
+]);
 
 function ensureOutputWidget(node) {
     let widget = node.widgets?.find((item) => item.name === OUTPUT_NAME);
@@ -131,7 +135,7 @@ function updateFromProgress({ nodeId, text }) {
         setOutput(source, text, "Streaming…");
         return;
     }
-    if (source.type !== MODERN_VLM_NODE) {
+    if (!STREAMING_SOURCE_NODES.has(source.type)) {
         return;
     }
     for (const target of connectedViewTextNodes(source)) {


### PR DESCRIPTION
## Summary
- replace the plaintext API-key widget with provider-bound server environment credentials and a legacy workflow scrubber
- add secure hosted LLM and multimodal VLM nodes with streaming, bounded frame sampling, redacted errors, HTTPS enforcement, and stateless requests
- add 22 current provider/model profiles across OpenAI, Google Gemini, Anthropic, xAI, DeepSeek, Groq, Mistral, Together, OpenRouter, and custom/local endpoints
- use Responses-first routing for OpenAI/xAI/Groq and native Anthropic Messages/vision
- release as 3.1.0 with a documented credential threat model

## Security
- built-in keys are pinned to official provider hosts
- custom endpoints can read only CUSTOM_API_KEY
- remote custom endpoints require HTTPS; keyless HTTP is loopback-only
- redirects and environment proxies are disabled by default
- legacy serialized keys are removed before graph configuration
- resolved credentials and common key forms are redacted from errors

## Validation
- 128 pytest tests pass
- Python compileall and dependency consistency pass
- source distribution and wheel build successfully
- installed wheel imports 56 nodes and all 22 profiles with no import errors
- actual OpenAI SDK wire smokes passed for Responses and Chat Completions with sampled image frames
- live ComfyUI /object_info exposes no api_key input
- live ComfyUI /prompt completed secure LLM and image VLM graphs
- refreshed ComfyUI browser exposes both secure API nodes with no extension errors
