### PR TITLE
Add adaptive video intelligence and text toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ComfyUI VLM Nodes
 
 Production-oriented vision-language, structured prompting, audio, and utility
-nodes for ComfyUI. Version 3.1 supports ComfyUI's selected NVIDIA CUDA, AMD
+nodes for ComfyUI. Version 3.2 supports ComfyUI's selected NVIDIA CUDA, AMD
 ROCm, Apple Metal, Intel XPU, and CPU device without replacing its PyTorch
 build. It removes startup installers and global accelerator cache flushes,
 adds real image/video batches and live token streaming, and uses ComfyUI model
@@ -9,18 +9,39 @@ residency and offloading.
 
 ## Modern model coverage
 
-The **Modern VLM** node provides one stable interface for:
+The **Modern VLM** node provides one stable interface with a deliberately
+small, 12-choice production picker:
 
-- Qwen 3.5 0.8B, 2B, 4B, 9B, 27B, and 35B-A3B
-- Qwen 3.6 27B
-- Qwen 3 VL 2B, 4B, 8B, and 30B-A3B Instruct
-- Qwen 2.5 VL 3B and 7B for existing workflows
-- Gemma 3 4B, 12B, and 27B IT
-- SmolVLM2 256M, 500M, and 2.2B video models
-- Liquid LFM2.5-VL 450M and 1.6B edge models
-- InternVL 3.5 1B and 2B standard Hugging Face checkpoints
-- Granite Vision 3.3 2B and 4.1 4B for documents, charts, and OCR
+- Qwen 3.5 0.8B and 4B
+- Qwen 3 VL 2B, 4B, and 8B Instruct
+- SmolVLM2 500M and 2.2B Video
+- Liquid LFM2.5-VL 450M
+- InternVL 3.5 1B
+- Granite Vision 4.1 4B
+- Gemma 3 4B IT
 - a compatible custom Hugging Face image-to-text repository
+
+The separate **[Legacy] Modern VLM Compatibility** node contains redundant,
+superseded, experimental, and very large tiers:
+
+- Qwen 3.5 2B, 9B, 27B, and 35B-A3B
+- Qwen 3.6 27B
+- Qwen 3 VL 30B-A3B Instruct
+- Qwen 2.5 VL 3B and 7B for existing workflows
+- Gemma 3 12B and 27B IT
+- SmolVLM2 256M Video
+- Liquid LFM2.5-VL 1.6B
+- InternVL 3.5 2B
+- Granite Vision 3.3 2B
+
+Previously saved `ModernVLM` workflows remain valid even when their selected
+model moved to Legacy. The server accepts every known catalog value for
+backward compatibility; only the visible new-workflow picker is curated.
+Dedicated Molmo, PaLI-Gemma, Qwen2-VL, MiniCPM-V, Kosmos-2, MC-LLaVA, UForm,
+and script-style MoonDream nodes are also collected under
+`VLM Nodes/Legacy/Model Loaders`. Maintained creator-facing Florence-2,
+Moondream2, JoyTag, llama.cpp/GGUF, detection, segmentation, tracking, API,
+and video-intelligence nodes stay in their functional categories.
 
 Sixteen curated sub-4B/low-VRAM choices are marked internally as the
 small-and-fast tier. The default is Qwen 3 VL 2B: it is much quicker to load
@@ -41,6 +62,32 @@ when ComfyUI rehydrates workflow output history. Disable `stream_output` for
 API-only or headless runs that do not need incremental UI updates. Streaming is
 best-effort and never changes the final `STRING` output or makes inference fail.
 
+## Text workflow toolkit
+
+The original `SimpleText`, `JsonToText`, and `ViewText` node IDs and their
+first `STRING` outputs remain stable for saved workflows. They now live in
+organized `VLM Nodes/Text` subcategories and expose descriptive names, search
+aliases, tooltips, appended metrics, and strict error messages:
+
+| Node | Purpose |
+| --- | --- |
+| `Text` (`SimpleText`) | Multiline/dynamic prompt source with optional edge/newline normalization and character, word, and line outputs |
+| `View Text (Streaming)` | Read-only live output with counts, copy, UTF-8 download, line wrapping, stream following, reroute traversal, and history rehydration |
+| `JSON to Text` | Plain or fenced JSON parsing with readable, values-only, key/value, pretty, and compact render modes |
+| `Text Join` | Join up to eight prompt/context values with empty-value removal and stable deduplication |
+| `Text Template` | Safe named placeholders from a JSON object plus four convenient live text sockets, with explicit missing-key policy |
+| `Text Clean` | Unicode NFC/NFKC, newline/whitespace cleanup, enclosing Markdown-fence removal, line deduplication, and deterministic length caps |
+| `Text Replace` | Literal or regex substitution with case, count, and missing-pattern controls |
+| `JSON Extract` | JSONPath-lite (`$.items[0]`) and RFC 6901 JSON Pointer extraction from plain or fenced model responses |
+| `Text Split / Batch` | Lines, paragraphs, delimiters, regex, CSV, or JSON arrays converted to a real mapped Comfy `STRING` list |
+| `Text Inspector` | Pass-through text plus characters, UTF-8 bytes, words, lines, rough token budget, SHA-256, and JSON metadata |
+
+The JSON utilities never evaluate code, follow references, access files, or
+make network requests. Template fields are direct names rather than Python
+attribute/index expressions. `approx_tokens` is deliberately labeled as a
+rough UTF-8 budget estimate; use the target model tokenizer when exact billing
+or context accounting matters.
+
 Specialized nodes remain available where a generic chat node would discard
 useful model capabilities:
 
@@ -52,7 +99,8 @@ useful model capabilities:
   checkpoint is not marked passed on the tested Torch/Transformers stack; use a
   small Modern VLM preset for production.
 - **Qwen2-VL**: image batches and real video-frame batches.
-- **Molmo, Kosmos-2, UForm, MCLLaVA, JoyTag, and MiniCPM-V 2.6 GGUF**.
+- **Legacy Molmo, Kosmos-2, UForm, MCLLaVA, and MiniCPM-V 2.6 GGUF**, plus
+  maintained JoyTag.
 - **llama.cpp LLaVA/GGUF**, structured prompt suggestions, OpenAI-compatible
   prompting, and AudioLDM2.
 
@@ -67,6 +115,8 @@ lists between nodes:
 | `VLM_TRACKS` | `comfyui-vlm/tracks`, version 1 | Durable object IDs with ordered observations over time |
 | `VLM_POINTS` | `comfyui-vlm/points`, version 1 | Pixel-coordinate points, including detection centers |
 | `VLM_EVENTS` | `comfyui-vlm/events`, version 1 | Ordered temporal events for downstream video analysis |
+| `VLM_VIDEO_SELECTION` | `comfyui-vlm/video-selection`, version 1 | Exact mapping from sampled images to source frame indices and timestamps |
+| `VLM_SCENE_STATE` | `comfyui-vlm/scene-state`, version 1 | Compact persistent objects, motion, visibility, and validated events |
 
 All spatial coordinates are source-image pixels. Bounding boxes are
 `[x1, y1, x2, y2]` with an exclusive right/bottom edge; polygons contain at
@@ -99,6 +149,45 @@ The utility layer converts without model-specific glue:
   background broadcasts safely across a video batch.
 - `VLMDetectionsFromJSON` and `VLMDetectionsToJSON` are the explicit API and
   persistence boundary for the versioned detection schema.
+
+### Adaptive video intelligence
+
+The video-intelligence layer keeps generative VLM inference out of the
+per-frame loop:
+
+- `VLMAdaptiveFrameSampler` combines scene-change, motion, track-change, and
+  uniform-coverage signals. It always preserves the real source frame index
+  and timestamp, enforces a frame budget, and returns selection/diagnostic
+  JSON. `Uniform coverage`, motion, scene, and track-priority modes remain
+  available for deterministic experiments.
+- `VLMVideoTemporalReasoner` is the one-node path. It adaptively samples the
+  input, downsizes only the VLM analysis copy (448-pixel longest side by
+  default), runs a recommended video-capable model, parses the result into
+  validated `VLM_EVENTS`, and returns summary, events, selection, sampled
+  previews, raw response, diagnostics, event JSON, and selection JSON.
+- `VLMVideoReasoningPrompt` and `VLMEventsFromVideoJSON` expose the same strict
+  timestamp/evidence contract for custom local or hosted VLM workflows.
+- `VLMTrackAwareCrops` chooses representative observations for each durable
+  track, adds configurable context, and letterboxes crops to one batch size.
+  This lets a VLM label identities without rereading every full frame.
+- `VLMBuildSceneState` converts tracks plus optional events into a compact
+  persistent world-state summary with first/last observation, current box,
+  confidence, state, and pixel velocity.
+
+Small VLMs commonly return evidence as positions in the supplied image batch
+even when asked for source indices. The parser accepts that form only when
+every value is an unambiguous valid supplied-image position, maps it back to
+the immutable source selection, and records the normalization mode. Arbitrary
+or unsupplied evidence frames, out-of-range timestamps, invalid confidence,
+duplicate evidence, malformed JSON, and non-finite values fail validation.
+
+On the repository's real-data smoke test (RTX 3090, Qwen3-VL 2B, 157-frame
+896x448 H.264 clip), hybrid sampling selected 12 frames in 0.30 seconds,
+reduced temporal inputs by 92.36%, reduced analysis pixels by 75%, used
+4.24 GiB peak allocated VRAM in the standalone runner, and produced a valid
+timestamped result in 35.17 seconds. The equivalent live ComfyUI `/prompt`
+graph completed in 37.45 seconds. These are one-machine measurements, not
+portable performance guarantees.
 
 ### Open-vocabulary image and video detection
 
@@ -202,6 +291,10 @@ API-format examples are in [`examples/vision`](examples/vision):
 - [`grounding_dino_image_api.json`](examples/vision/grounding_dino_image_api.json)
 - [`sam2_video_tracking_api.json`](examples/vision/sam2_video_tracking_api.json)
 - [`sam3_core_adapter_blueprint_api.json`](examples/vision/sam3_core_adapter_blueprint_api.json)
+- [`video_temporal_reasoning_api.json`](examples/vision/video_temporal_reasoning_api.json)
+
+The dependency-free text-toolkit example is
+[`examples/text_toolkit_api.json`](examples/text_toolkit_api.json).
 
 Upload the named media to ComfyUI's input directory, adjust the filenames and
 labels, then submit the JSON object as the `prompt` value to `/prompt`. These

--- a/__init__.py
+++ b/__init__.py
@@ -31,6 +31,7 @@ node_list = [
     "suggest",
     "tracking",
     "uform",
+    "video_intelligence",
     "vision_utils",
 ]
 

--- a/examples/text_toolkit_api.json
+++ b/examples/text_toolkit_api.json
@@ -1,0 +1,57 @@
+{
+  "1": {
+    "class_type": "SimpleText",
+    "inputs": {
+      "input_text": "Model response:\n```json\n{\"scene\":{\"subject\":\"warehouse robot\",\"action\":\"moving a blue crate\"}}\n```"
+    }
+  },
+  "2": {
+    "class_type": "VLMJSONExtract",
+    "inputs": {
+      "text": [
+        "1",
+        0
+      ],
+      "path": "$.scene.action",
+      "output_format": "Text",
+      "if_missing": "Error",
+      "default_value": ""
+    }
+  },
+  "3": {
+    "class_type": "VLMTextTemplate",
+    "inputs": {
+      "template": "{instruction}\n\nObserved action: {text1}",
+      "variables_json": "{\"instruction\":\"Write one concise video-generation prompt.\"}",
+      "missing_values": "Error",
+      "text1": [
+        "2",
+        0
+      ]
+    }
+  },
+  "4": {
+    "class_type": "VLMTextClean",
+    "inputs": {
+      "text": [
+        "3",
+        0
+      ],
+      "unicode_normalization": "NFC",
+      "whitespace": "Normalize line endings",
+      "trim_edges": true,
+      "remove_outer_markdown_fence": false,
+      "deduplicate_lines": false,
+      "max_characters": 0
+    }
+  },
+  "5": {
+    "class_type": "ViewText",
+    "inputs": {
+      "text": [
+        "4",
+        0
+      ]
+    }
+  }
+}

--- a/examples/vision/video_temporal_reasoning_api.json
+++ b/examples/vision/video_temporal_reasoning_api.json
@@ -1,0 +1,91 @@
+{
+  "1": {
+    "class_type": "LoadVideo",
+    "inputs": {
+      "file": "video_understanding_input.mp4"
+    }
+  },
+  "2": {
+    "class_type": "GetVideoComponents",
+    "inputs": {
+      "video": [
+        "1",
+        0
+      ]
+    }
+  },
+  "3": {
+    "class_type": "VLMVideoTemporalReasoner",
+    "inputs": {
+      "frames": [
+        "2",
+        0
+      ],
+      "fps": [
+        "2",
+        2
+      ],
+      "task": "Detailed temporal summary",
+      "question": "Describe what happens over time and identify the visible evidence.",
+      "model": "Qwen 3 VL 2B Instruct",
+      "custom_model_id": "",
+      "memory_mode": "ComfyUI managed (BF16)",
+      "max_frames": 16,
+      "max_events": 24,
+      "max_new_tokens": 768,
+      "strategy": "Hybrid: scene + motion + tracks",
+      "minimum_gap_seconds": 0.15,
+      "analysis_max_side": 448,
+      "attention_mode": "Auto (SDPA)",
+      "enable_thinking": false,
+      "strict_output": true,
+      "unload_after": false,
+      "stream_output": true
+    }
+  },
+  "4": {
+    "class_type": "ViewText",
+    "inputs": {
+      "text": [
+        "3",
+        0
+      ]
+    }
+  },
+  "5": {
+    "class_type": "ViewText",
+    "inputs": {
+      "text": [
+        "3",
+        6
+      ]
+    }
+  },
+  "6": {
+    "class_type": "ViewText",
+    "inputs": {
+      "text": [
+        "3",
+        7
+      ]
+    }
+  },
+  "7": {
+    "class_type": "ViewText",
+    "inputs": {
+      "text": [
+        "3",
+        5
+      ]
+    }
+  },
+  "8": {
+    "class_type": "PreviewImage",
+    "inputs": {
+      "images": [
+        "3",
+        3
+      ]
+    }
+  }
+}

--- a/nodes/joytag.py
+++ b/nodes/joytag.py
@@ -118,7 +118,7 @@ class Joytag(CachedModelNode):
 
     RETURN_TYPES = ("STRING",)
     FUNCTION = "tags"
-    CATEGORY = "VLM Nodes/JoyTag"
+    CATEGORY = "VLM Nodes/Vision/Tagging"
 
     def tags(
         self,

--- a/nodes/kosmos2.py
+++ b/nodes/kosmos2.py
@@ -100,7 +100,7 @@ class Kosmos2model(CachedModelNode):
 
     RETURN_TYPES = ("STRING",)
     FUNCTION = "new_model_generate_predictions"
-    CATEGORY = "VLM Nodes/Kosmos-2"
+    CATEGORY = "VLM Nodes/Legacy/Model Loaders"
 
     def new_model_generate_predictions(
         self,

--- a/nodes/mcllava.py
+++ b/nodes/mcllava.py
@@ -126,7 +126,7 @@ class MCLLaVAModel(CachedModelNode):
 
     RETURN_TYPES = ("STRING",)
     FUNCTION = "generate_image_description"
-    CATEGORY = "VLM Nodes/MC-LLaVA"
+    CATEGORY = "VLM Nodes/Legacy/Model Loaders"
 
     def generate_image_description(
         self,

--- a/nodes/minicpm.py
+++ b/nodes/minicpm.py
@@ -160,7 +160,7 @@ class MiniCPMNode(CachedModelNode):
 
     RETURN_TYPES = ("STRING",)
     FUNCTION = "generate"
-    CATEGORY = "VLM Nodes/MiniCPM-V"
+    CATEGORY = "VLM Nodes/Legacy/Model Loaders"
 
     def generate(
         self,

--- a/nodes/modern_vlm.py
+++ b/nodes/modern_vlm.py
@@ -32,6 +32,7 @@ from .runtime import (
     tensor_batch_to_pil,
     torch_dtype,
 )
+from .vision_types import VLM_VIDEO_SELECTION, VideoFrameSelection
 
 
 @dataclass(frozen=True)
@@ -189,6 +190,24 @@ MODEL_CATALOG = {
         trust_remote_code=True,
     ),
 }
+
+RECOMMENDED_MODEL_LABELS = (
+    "Qwen 3.5 0.8B (fastest current)",
+    "Qwen 3.5 4B (recommended)",
+    "Qwen 3 VL 2B Instruct",
+    "Qwen 3 VL 4B Instruct",
+    "Qwen 3 VL 8B Instruct",
+    "SmolVLM2 500M Video (low VRAM)",
+    "SmolVLM2 2.2B Video",
+    "LFM2.5 VL 450M (edge)",
+    "InternVL 3.5 1B HF",
+    "Granite Vision 4.1 4B (structured documents)",
+    "Gemma 3 4B IT (license acceptance required)",
+    "Custom Hugging Face model",
+)
+LEGACY_MODEL_LABELS = tuple(
+    label for label in MODEL_CATALOG if label not in RECOMMENDED_MODEL_LABELS
+)
 
 MEMORY_MODES = (
     "ComfyUI managed (BF16)",
@@ -445,6 +464,7 @@ class ModernVLMPredictor:
         fps: float = 1.0,
         enable_thinking: bool = False,
         stream_callback: Callable[[str], None] | None = None,
+        video_selection: VideoFrameSelection | None = None,
     ) -> str:
         primary_images = (
             tensor_batch_to_pil(images) if images is not None else []
@@ -461,6 +481,27 @@ class ModernVLMPredictor:
                 f"{self.spec.family} does not advertise video support. "
                 "Disconnect video_frames or select Qwen/SmolVLM2."
             )
+        if video_selection is not None:
+            if video is None:
+                raise ValueError(
+                    "video_selection requires a connected video_frames batch."
+                )
+            if not isinstance(video_selection, VideoFrameSelection):
+                raise TypeError("video_selection must be a VLM Video Selection.")
+            if len(video_selection.frames) != len(video):
+                raise ValueError(
+                    "video_selection frame count must match video_frames."
+                )
+            source_aspect = video_selection.width / video_selection.height
+            analysis_aspect = video[0].width / video[0].height
+            if abs(source_aspect - analysis_aspect) > max(
+                0.01,
+                source_aspect * 0.01,
+            ):
+                raise ValueError(
+                    "video_selection and video_frames must have the same "
+                    "aspect ratio."
+                )
 
         results = []
         # A connected video is the primary visual input. Including ComfyUI's
@@ -483,25 +524,49 @@ class ModernVLMPredictor:
                 if video is not None
                 else [{"type": "image", "image": image}]
             )
-            effective_prompt = (
-                f"The video frames are sampled at {float(fps):g} FPS.\n\n{prompt}"
-                if video is not None
-                else prompt
-            )
+            if video is not None and video_selection is not None:
+                timeline = ", ".join(
+                    f"{position}=frame {frame.source_frame_index} "
+                    f"at {frame.timestamp:.6f}s"
+                    for position, frame in enumerate(video_selection.frames)
+                )
+                effective_prompt = (
+                    "The supplied video images are irregular samples from one "
+                    f"{video_selection.source_frame_count}-frame video at "
+                    f"{video_selection.fps:g} FPS. Supplied-image mapping: "
+                    f"{timeline}.\n\n{prompt}"
+                )
+            elif video is not None:
+                effective_prompt = (
+                    f"The video frames are sampled at {float(fps):g} FPS.\n\n"
+                    f"{prompt}"
+                )
+            else:
+                effective_prompt = prompt
             content.append({"type": "text", "text": effective_prompt})
             messages.append({"role": "user", "content": content})
 
             metadata = None
             if video is not None:
-                frame_rate = float(fps)
-                metadata = {
-                    "total_num_frames": len(video),
-                    "fps": frame_rate,
-                    "duration": len(video) / frame_rate,
-                    "frames_indices": list(range(len(video))),
-                    "width": video[0].width,
-                    "height": video[0].height,
-                }
+                if video_selection is not None:
+                    metadata = {
+                        "total_num_frames": video_selection.source_frame_count,
+                        "fps": video_selection.fps,
+                        "duration": video_selection.duration,
+                        "frames_indices": list(video_selection.indices),
+                        "width": video[0].width,
+                        "height": video[0].height,
+                    }
+                else:
+                    frame_rate = float(fps)
+                    metadata = {
+                        "total_num_frames": len(video),
+                        "fps": frame_rate,
+                        "duration": len(video) / frame_rate,
+                        "frames_indices": list(range(len(video))),
+                        "width": video[0].width,
+                        "height": video[0].height,
+                    }
             inputs = self._inputs(
                 messages,
                 enable_thinking,
@@ -607,7 +672,7 @@ class ModernVLM(CachedModelNode):
                     },
                 ),
                 "model": (
-                    list(MODEL_CATALOG),
+                    list(RECOMMENDED_MODEL_LABELS),
                     {"default": "Qwen 3 VL 2B Instruct"},
                 ),
                 "custom_model_id": ("STRING", {"default": ""}),
@@ -638,6 +703,7 @@ class ModernVLM(CachedModelNode):
                     },
                 ),
                 "video_frames": ("IMAGE",),
+                "video_selection": (VLM_VIDEO_SELECTION,),
                 "fps": (
                     "FLOAT",
                     {"default": 1.0, "min": 0.1, "max": 60.0, "step": 0.1},
@@ -666,6 +732,15 @@ class ModernVLM(CachedModelNode):
     FUNCTION = "run"
     CATEGORY = "VLM Nodes/Modern"
 
+    @classmethod
+    def VALIDATE_INPUTS(cls, model):
+        # The visible combo is deliberately curated. Accepting every known
+        # catalog value here keeps workflows saved before the curation fully
+        # executable even when their model now lives under Legacy.
+        if model not in MODEL_CATALOG:
+            return f"Unsupported Modern VLM model {model!r}."
+        return True
+
     def run(
         self,
         prompt,
@@ -678,6 +753,7 @@ class ModernVLM(CachedModelNode):
         image=None,
         system_prompt="You are an expert visual analyst.",
         video_frames=None,
+        video_selection=None,
         fps=1.0,
         attention_mode="Auto (SDPA)",
         enable_thinking=False,
@@ -705,25 +781,45 @@ class ModernVLM(CachedModelNode):
         try:
             return (
                 predictor.generate(
-                    image,
-                    prompt,
-                    system_prompt,
-                    max_new_tokens,
-                    temperature,
-                    top_p,
-                    video_frames,
-                    fps,
-                    enable_thinking,
-                    stream_callback,
+                    images=image,
+                    prompt=prompt,
+                    system_prompt=system_prompt,
+                    max_new_tokens=max_new_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                    video_frames=video_frames,
+                    fps=fps,
+                    video_selection=video_selection,
+                    enable_thinking=enable_thinking,
+                    stream_callback=stream_callback,
                 ),
             )
         finally:
             self.maybe_clear_model(unload_after)
 
 
-NODE_CLASS_MAPPINGS = {"ModernVLM": ModernVLM}
+class LegacyModernVLM(ModernVLM):
+    """Compatibility surface for redundant, superseded, and very large tiers."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        inputs = super().INPUT_TYPES()
+        inputs["required"]["model"] = (
+            list(LEGACY_MODEL_LABELS),
+            {"default": LEGACY_MODEL_LABELS[0]},
+        )
+        return inputs
+
+    CATEGORY = "VLM Nodes/Legacy/Model Loaders"
+
+
+NODE_CLASS_MAPPINGS = {
+    "ModernVLM": ModernVLM,
+    "LegacyModernVLM": LegacyModernVLM,
+}
 NODE_DISPLAY_NAME_MAPPINGS = {
     "ModernVLM": (
         "Modern VLM (Qwen / SmolVLM2 / LFM / InternVL / Granite / Gemma)"
-    )
+    ),
+    "LegacyModernVLM": "[Legacy] Modern VLM Compatibility",
 }

--- a/nodes/molmo.py
+++ b/nodes/molmo.py
@@ -155,7 +155,7 @@ class MolmoNode(CachedModelNode):
 
     RETURN_TYPES = ("STRING",)
     FUNCTION = "generate"
-    CATEGORY = "VLM Nodes/Molmo"
+    CATEGORY = "VLM Nodes/Legacy/Model Loaders"
 
     def generate(
         self,

--- a/nodes/moondream2.py
+++ b/nodes/moondream2.py
@@ -134,7 +134,7 @@ class Moondream2model(CachedModelNode):
 
     RETURN_TYPES = ("STRING",)
     FUNCTION = "moondream2_generate_predictions"
-    CATEGORY = "VLM Nodes/Moondream2"
+    CATEGORY = "VLM Nodes/Modern/Edge"
 
     def moondream2_generate_predictions(
         self,

--- a/nodes/moondream_script.py
+++ b/nodes/moondream_script.py
@@ -25,7 +25,7 @@ class MoonDream(CachedModelNode):
 
     RETURN_TYPES = ("STRING",)
     FUNCTION = "answer_questions"
-    CATEGORY = "VLM Nodes/MoonDream"
+    CATEGORY = "VLM Nodes/Legacy/Model Loaders"
 
     def answer_questions(self, image, question, unload_after=False):
         predictor = self.get_or_create_model(

--- a/nodes/paligemma.py
+++ b/nodes/paligemma.py
@@ -263,7 +263,7 @@ class Paligemma(CachedModelNode):
     RETURN_TYPES = ("STRING", "MASK", "IMAGE")
     RETURN_NAMES = ("description", "mask", "visualization")
     FUNCTION = "process_task"
-    CATEGORY = "VLM Nodes/Paligemma"
+    CATEGORY = "VLM Nodes/Legacy/Model Loaders"
 
     def process_task(
         self,

--- a/nodes/qwen2vl.py
+++ b/nodes/qwen2vl.py
@@ -347,7 +347,7 @@ class Qwen2VLNode(CachedModelNode):
 
     RETURN_TYPES = ("STRING",)
     FUNCTION = "generate"
-    CATEGORY = "VLM Nodes/Qwen2-VL"
+    CATEGORY = "VLM Nodes/Legacy/Model Loaders"
 
     def generate(
         self,

--- a/nodes/simpletext.py
+++ b/nodes/simpletext.py
@@ -1,101 +1,1075 @@
+"""Reliable, composable text utilities for VLM and creator workflows.
+
+The original node IDs and their first STRING outputs are intentionally kept
+stable.  New outputs are appended so existing workflow links remain valid.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import io
 import json
+import re
+import unicodedata
+from typing import Any
+
+
+TEXT_CATEGORY = "VLM Nodes/Text"
+CREATE_CATEGORY = f"{TEXT_CATEGORY}/Create"
+TRANSFORM_CATEGORY = f"{TEXT_CATEGORY}/Transform"
+JSON_CATEGORY = f"{TEXT_CATEGORY}/JSON"
+INSPECT_CATEGORY = f"{TEXT_CATEGORY}/Inspect"
+
+_MISSING = object()
+_JSON_FENCE = re.compile(
+    r"```(?:json|javascript|js)?\s*(.*?)```",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+_WHOLE_FENCE = re.compile(
+    r"^\s*```[^\n`]*\n?(.*?)\n?```\s*$",
+    flags=re.DOTALL,
+)
+_TEMPLATE_FIELD = re.compile(r"\{([A-Za-z_][A-Za-z0-9_.-]*)\}")
+
+
+def _metrics(text: str) -> dict[str, Any]:
+    encoded = text.encode("utf-8")
+    return {
+        "characters": len(text),
+        "utf8_bytes": len(encoded),
+        "words": len(re.findall(r"\S+", text)),
+        "lines": 0 if not text else text.count("\n") + 1,
+        "approx_tokens": 0 if not text else max(1, (len(encoded) + 3) // 4),
+        "sha256": hashlib.sha256(encoded).hexdigest(),
+    }
+
+
+def _json_text(value: Any, *, pretty: bool = False) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        indent=2 if pretty else None,
+        separators=None if pretty else (",", ":"),
+    )
+
+
+def _display_value(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return _json_text(value)
+
+
+def _load_json_document(text: str) -> Any:
+    stripped = text.strip()
+    if not stripped:
+        raise ValueError("JSON input is empty.")
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError as direct_error:
+        for match in _JSON_FENCE.finditer(stripped):
+            try:
+                return json.loads(match.group(1).strip())
+            except json.JSONDecodeError:
+                continue
+
+        decoder = json.JSONDecoder()
+        for match in re.finditer(r"[\[{]", stripped):
+            try:
+                value, _end = decoder.raw_decode(stripped[match.start() :])
+                return value
+            except json.JSONDecodeError:
+                continue
+        raise ValueError(
+            "Input does not contain a valid JSON document "
+            f"(line {direct_error.lineno}, column {direct_error.colno})."
+        ) from direct_error
+
+
+def _path_tokens(path: str) -> list[str | int]:
+    value = path.strip()
+    if not value or value == "$":
+        return []
+    if value.startswith("/"):
+        return [
+            token.replace("~1", "/").replace("~0", "~")
+            for token in value[1:].split("/")
+        ]
+
+    if value.startswith("$"):
+        value = value[1:]
+    tokens: list[str | int] = []
+    index = 0
+    while index < len(value):
+        if value[index] == ".":
+            index += 1
+            continue
+        if value[index] == "[":
+            end = value.find("]", index + 1)
+            if end < 0:
+                raise ValueError(f"Unclosed bracket in JSON path: {path!r}.")
+            raw = value[index + 1 : end].strip()
+            if not raw:
+                raise ValueError(f"Empty bracket in JSON path: {path!r}.")
+            if raw[0] in "\"'" and raw[-1:] == raw[0]:
+                if raw[0] == '"':
+                    token: str | int = json.loads(raw)
+                else:
+                    token = raw[1:-1].replace("\\'", "'")
+            elif re.fullmatch(r"-?\d+", raw):
+                token = int(raw)
+            else:
+                token = raw
+            tokens.append(token)
+            index = end + 1
+            continue
+        end = index
+        while end < len(value) and value[end] not in ".[":
+            end += 1
+        token_text = value[index:end]
+        if not token_text:
+            raise ValueError(f"Invalid JSON path: {path!r}.")
+        tokens.append(token_text)
+        index = end
+    return tokens
+
+
+def _resolve_json_path(document: Any, path: str) -> Any:
+    current = document
+    for token in _path_tokens(path):
+        if isinstance(current, dict):
+            key = str(token)
+            if key not in current:
+                return _MISSING
+            current = current[key]
+        elif isinstance(current, list):
+            if isinstance(token, str) and re.fullmatch(r"-?\d+", token):
+                token = int(token)
+            if not isinstance(token, int):
+                return _MISSING
+            resolved = token if token >= 0 else len(current) + token
+            if resolved < 0 or resolved >= len(current):
+                return _MISSING
+            current = current[resolved]
+        else:
+            return _MISSING
+    return current
+
+
+def _flatten_json(value: Any, prefix: str = "$") -> list[tuple[str, Any]]:
+    if isinstance(value, dict):
+        flattened: list[tuple[str, Any]] = []
+        for key, child in value.items():
+            child_path = f"{prefix}.{key}" if prefix else str(key)
+            flattened.extend(_flatten_json(child, child_path))
+        return flattened or [(prefix, {})]
+    if isinstance(value, list):
+        flattened = []
+        for index, child in enumerate(value):
+            flattened.extend(_flatten_json(child, f"{prefix}[{index}]"))
+        return flattened or [(prefix, [])]
+    return [(prefix, value)]
+
+
+def _readable_json(value: Any, separator: str, strip_generation_verbs: bool) -> str:
+    if not isinstance(value, dict):
+        if isinstance(value, list):
+            return separator.join(_display_value(item) for item in value)
+        return _display_value(value)
+
+    parts = []
+    for key, child in value.items():
+        if key == "prompt" and isinstance(child, str):
+            if strip_generation_verbs:
+                child = re.sub(
+                    r"\b(?:create|generate)\b",
+                    "",
+                    child,
+                    flags=re.IGNORECASE,
+                )
+                child = re.sub(r"[ \t]{2,}", " ", child).strip()
+            parts.append(child)
+        elif key.lower().startswith("sugg"):
+            parts.append(_display_value(child))
+        elif isinstance(child, list):
+            parts.append(f"{key}: {', '.join(_display_value(item) for item in child)}")
+        elif isinstance(child, dict):
+            parts.append(f"{key}: {_json_text(child, pretty=True)}")
+        else:
+            parts.append(f"{key}: {_display_value(child)}")
+    return separator.join(parts)
+
+
 class SimpleText:
-    def __init__(self):
-    	pass
+    """A stable text source with optional normalization and useful metadata."""
+
+    DESCRIPTION = (
+        "Create reusable text while preserving the exact original SimpleText "
+        "node ID and first output."
+    )
+    SEARCH_ALIASES = ["text", "prompt", "string", "multiline text"]
 
     @classmethod
     def INPUT_TYPES(cls):
         return {
             "required": {
                 "input_text": (
-                            "STRING",
-                            {
-                                "multiline": True,
-                                "default": "",
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "",
+                        "dynamicPrompts": True,
+                        "placeholder": "Enter text or connect a STRING.",
+                        "tooltip": "Text passed to downstream nodes.",
+                    },
+                ),
+            },
+            "optional": {
+                "trim_edges": (
+                    "BOOLEAN",
+                    {
+                        "default": False,
+                        "tooltip": "Remove whitespace only at the start and end.",
+                    },
+                ),
+                "normalize_newlines": (
+                    "BOOLEAN",
+                    {
+                        "default": False,
+                        "tooltip": "Convert CRLF and CR line endings to LF.",
                     },
                 ),
             },
         }
 
-    RETURN_TYPES = ("STRING",)
-
+    RETURN_TYPES = ("STRING", "INT", "INT", "INT")
+    RETURN_NAMES = ("text", "characters", "words", "lines")
+    OUTPUT_TOOLTIPS = (
+        "The text value.",
+        "Unicode character count.",
+        "Whitespace-delimited word count.",
+        "Line count.",
+    )
     FUNCTION = "simple_text"
+    CATEGORY = CREATE_CATEGORY
 
-    CATEGORY = "VLM Nodes/Text"
+    def simple_text(
+        self,
+        input_text: str,
+        trim_edges: bool = False,
+        normalize_newlines: bool = False,
+    ):
+        text = str(input_text)
+        if normalize_newlines:
+            text = text.replace("\r\n", "\n").replace("\r", "\n")
+        if trim_edges:
+            text = text.strip()
+        metrics = _metrics(text)
+        return (
+            text,
+            metrics["characters"],
+            metrics["words"],
+            metrics["lines"],
+        )
 
-    def simple_text(self, input_text):
 
-        return (input_text, )
-    
 class JsonToText:
-    def __init__(self):
-    	pass
+    """Render model JSON without losing the original compatibility behavior."""
+
+    DESCRIPTION = (
+        "Parse plain or fenced JSON and render it as readable text, values, "
+        "key/value lines, or canonical JSON."
+    )
+    SEARCH_ALIASES = ["json to string", "json render", "format json"]
 
     @classmethod
-    def INPUT_TYPES(s):
+    def INPUT_TYPES(cls):
         return {
             "required": {
-                "text": ("STRING",),
-            }
+                "text": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "{}",
+                        "placeholder": "JSON or a response containing a JSON block.",
+                    },
+                ),
+            },
+            "optional": {
+                "format_mode": (
+                    [
+                        "Smart readable (legacy compatible)",
+                        "Pretty JSON",
+                        "Compact JSON",
+                        "Values only",
+                        "Key/value lines",
+                    ],
+                    {"default": "Smart readable (legacy compatible)"},
+                ),
+                "json_path": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "placeholder": "$.result.items[0] or /result/items/0",
+                    },
+                ),
+                "separator": (
+                    "STRING",
+                    {
+                        "default": "\n\n",
+                        "multiline": True,
+                        "tooltip": "Used by readable and values-only modes.",
+                    },
+                ),
+                "strip_generation_verbs": (
+                    "BOOLEAN",
+                    {
+                        "default": True,
+                        "tooltip": (
+                            "Preserves the original node's prompt-field behavior."
+                        ),
+                    },
+                ),
+            },
         }
 
-    RETURN_TYPES = ("STRING",)
+    RETURN_TYPES = ("STRING", "STRING", "INT")
+    RETURN_NAMES = ("text", "canonical_json", "items")
     FUNCTION = "json_to_text"
     OUTPUT_NODE = True
+    CATEGORY = JSON_CATEGORY
 
-    CATEGORY = "VLM Nodes/Text"
+    def json_to_text(
+        self,
+        text: str,
+        format_mode: str = "Smart readable (legacy compatible)",
+        json_path: str = "",
+        separator: str = "\n\n",
+        strip_generation_verbs: bool = True,
+    ):
+        document = _load_json_document(text)
+        selected = _resolve_json_path(document, json_path)
+        if selected is _MISSING:
+            raise ValueError(f"JSON path was not found: {json_path!r}.")
 
-    def json_to_text(self, text):
-        # Parse the combined JSON string
-        loaded_json = json.loads(text)
+        if format_mode == "Pretty JSON":
+            output = _json_text(selected, pretty=True)
+        elif format_mode == "Compact JSON":
+            output = _json_text(selected)
+        elif format_mode == "Values only":
+            output = separator.join(
+                _display_value(value) for _path, value in _flatten_json(selected)
+            )
+        elif format_mode == "Key/value lines":
+            output = "\n".join(
+                f"{path}: {_display_value(value)}"
+                for path, value in _flatten_json(selected)
+            )
+        elif format_mode == "Smart readable (legacy compatible)":
+            output = _readable_json(
+                selected,
+                separator,
+                bool(strip_generation_verbs),
+            )
+        else:
+            raise ValueError(f"Unknown JSON render mode: {format_mode!r}.")
 
-        # Process each element in the combined data
-        merged_ideas = []
-        excluded_keywords = ['create', 'generate']  # Words to exclude in the prompt
+        canonical = _json_text(selected)
+        item_count = len(selected) if isinstance(selected, (dict, list)) else 1
+        return {
+            "ui": {"text": [output]},
+            "result": (output, canonical, item_count),
+        }
 
-        for key, value in loaded_json.items():
-            if key == "prompt":  # Special handling for the "prompt" key
-                value = ' '.join(word for word in value.split() if word.lower() not in excluded_keywords)
-                merged_ideas.append(value)  # Append the processed prompt without the key
-            elif key.startswith("sugg"):  # Handle keys that start with "suggestion"
-            # Directly append the value, skipping the key
-                merged_ideas.append(value)
-            elif isinstance(value, list):  # Unpack the list if the value is a list and include the key
-                merged_ideas.append(f"{key}: {', '.join(value)}")
-            else:  # For non-list values other than "prompt", include the key
-                merged_ideas.append(f"{key}: {value}")
-
-        formatted_output_str = "\n\n".join(merged_ideas)
-        return {"ui": {"text": [formatted_output_str]}, "result": (formatted_output_str,)}
 
 class ViewText:
-    def __init__(self):
-        pass
+    """Display final and streamed text safely in a read-only frontend widget."""
+
+    DESCRIPTION = (
+        "Inspect, copy, and download text. Connected VLM/API responses stream "
+        "into the widget without changing the final STRING output."
+    )
+    SEARCH_ALIASES = ["show text", "preview text", "display string", "text output"]
 
     @classmethod
-    def INPUT_TYPES(s):
+    def INPUT_TYPES(cls):
         return {
             "required": {
-                "text": ("STRING",),
+                "text": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "multiline": True,
+                        "placeholder": "Connect any STRING output.",
+                    },
+                ),
             }
         }
 
-    RETURN_TYPES = ("STRING",)
+    RETURN_TYPES = ("STRING", "INT", "INT", "INT", "STRING")
+    RETURN_NAMES = ("text", "characters", "words", "lines", "stats_json")
     FUNCTION = "view_text"
     OUTPUT_NODE = True
+    CATEGORY = INSPECT_CATEGORY
 
-    CATEGORY = "VLM Nodes/Text"
+    def view_text(self, text: str):
+        value = str(text)
+        metrics = _metrics(value)
+        stats = _json_text(metrics)
+        return {
+            "ui": {"text": [value], "text_stats": [metrics]},
+            "result": (
+                value,
+                metrics["characters"],
+                metrics["words"],
+                metrics["lines"],
+                stats,
+            ),
+        }
 
-    def view_text(self, text):
-        # Parse the combined JSON string
-        return {"ui": {"text": [text]}, "result": (text,)}
 
-# A dictionary that contains all nodes you want to export with their names
-NODE_CLASS_MAPPINGS = {"SimpleText": SimpleText,
-                       "JsonToText": JsonToText,
-                       "ViewText": ViewText}
+class VLMTextJoin:
+    DESCRIPTION = (
+        "Join up to eight text values, optionally dropping empty or duplicate "
+        "parts. This replaces long chains of concatenation nodes."
+    )
+    SEARCH_ALIASES = ["text concat", "join text", "merge strings", "combine prompts"]
 
-# A dictionary that contains the friendly/humanly readable titles for the nodes
-NODE_DISPLAY_NAME_MAPPINGS = {"SimpleText": "SimpleText",
-                              "JsonToText": "JsonToText",
-                              "ViewText": "ViewText"}
+    @classmethod
+    def INPUT_TYPES(cls):
+        optional = {
+            f"text_{letter}": (
+                "STRING",
+                {"default": "", "multiline": True},
+            )
+            for letter in "bcdefgh"
+        }
+        return {
+            "required": {
+                "text_a": ("STRING", {"default": "", "multiline": True}),
+                "separator": (
+                    [
+                        "New line",
+                        "Blank line",
+                        "Space",
+                        "Comma",
+                        "Custom",
+                    ],
+                    {"default": "New line"},
+                ),
+                "custom_separator": (
+                    "STRING",
+                    {
+                        "default": " | ",
+                        "tooltip": "Used only when separator is Custom.",
+                    },
+                ),
+                "trim_parts": ("BOOLEAN", {"default": True}),
+                "drop_empty": ("BOOLEAN", {"default": True}),
+                "deduplicate": ("BOOLEAN", {"default": False}),
+            },
+            "optional": optional,
+        }
+
+    RETURN_TYPES = ("STRING", "STRING", "INT")
+    RETURN_NAMES = ("text", "parts_json", "part_count")
+    FUNCTION = "join"
+    CATEGORY = CREATE_CATEGORY
+
+    def join(
+        self,
+        text_a: str,
+        separator: str,
+        custom_separator: str,
+        trim_parts: bool,
+        drop_empty: bool,
+        deduplicate: bool,
+        **kwargs,
+    ):
+        separators = {
+            "New line": "\n",
+            "Blank line": "\n\n",
+            "Space": " ",
+            "Comma": ", ",
+            "Custom": custom_separator,
+        }
+        if separator not in separators:
+            raise ValueError(f"Unknown separator: {separator!r}.")
+        values = [str(text_a)]
+        values.extend(str(kwargs.get(f"text_{letter}", "")) for letter in "bcdefgh")
+        if trim_parts:
+            values = [value.strip() for value in values]
+        if drop_empty:
+            values = [value for value in values if value]
+        if deduplicate:
+            values = list(dict.fromkeys(values))
+        return (
+            separators[separator].join(values),
+            _json_text(values),
+            len(values),
+        )
+
+
+class VLMTextTemplate:
+    DESCRIPTION = (
+        "Render {named} placeholders from a JSON object plus four convenient "
+        "{text1}…{text4} sockets. Missing values are handled explicitly."
+    )
+    SEARCH_ALIASES = ["prompt template", "format text", "text variables"]
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "template": (
+                    "STRING",
+                    {
+                        "default": "{instruction}\n\nContext:\n{text1}",
+                        "multiline": True,
+                        "dynamicPrompts": False,
+                    },
+                ),
+                "variables_json": (
+                    "STRING",
+                    {
+                        "default": '{"instruction":"Describe the input accurately."}',
+                        "multiline": True,
+                    },
+                ),
+                "missing_values": (
+                    ["Keep placeholder", "Empty string", "Error"],
+                    {"default": "Error"},
+                ),
+            },
+            "optional": {
+                f"text{index}": (
+                    "STRING",
+                    {"default": "", "multiline": True},
+                )
+                for index in range(1, 5)
+            },
+        }
+
+    RETURN_TYPES = ("STRING", "STRING", "STRING")
+    RETURN_NAMES = ("text", "variables_json", "missing_keys_json")
+    FUNCTION = "render"
+    CATEGORY = CREATE_CATEGORY
+
+    def render(
+        self,
+        template: str,
+        variables_json: str,
+        missing_values: str,
+        **kwargs,
+    ):
+        variables = _load_json_document(variables_json or "{}")
+        if not isinstance(variables, dict):
+            raise ValueError("Template variables must be a JSON object.")
+        variables = dict(variables)
+        for index in range(1, 5):
+            value = kwargs.get(f"text{index}", _MISSING)
+            if value is not _MISSING and value != "":
+                variables[f"text{index}"] = str(value)
+
+        left_token = "\x00VLM_LEFT_BRACE\x00"
+        right_token = "\x00VLM_RIGHT_BRACE\x00"
+        prepared = str(template).replace("{{", left_token).replace("}}", right_token)
+        missing: list[str] = []
+
+        def replace(match: re.Match[str]) -> str:
+            name = match.group(1)
+            if name in variables:
+                return _display_value(variables[name])
+            if name not in missing:
+                missing.append(name)
+            if missing_values == "Keep placeholder":
+                return match.group(0)
+            if missing_values == "Empty string":
+                return ""
+            if missing_values == "Error":
+                return match.group(0)
+            raise ValueError(f"Unknown missing-value policy: {missing_values!r}.")
+
+        rendered = _TEMPLATE_FIELD.sub(replace, prepared)
+        if missing and missing_values == "Error":
+            raise ValueError(
+                "Template variables are missing: " + ", ".join(missing) + "."
+            )
+        rendered = rendered.replace(left_token, "{").replace(right_token, "}")
+        return (
+            rendered,
+            _json_text(variables),
+            _json_text(missing),
+        )
+
+
+class VLMTextClean:
+    DESCRIPTION = (
+        "Normalize Unicode/newlines, remove an enclosing Markdown fence, "
+        "collapse whitespace, deduplicate lines, and cap length deterministically."
+    )
+    SEARCH_ALIASES = ["clean prompt", "normalize text", "strip markdown"]
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "text": ("STRING", {"default": "", "multiline": True}),
+                "unicode_normalization": (
+                    ["NFC", "NFKC", "None"],
+                    {"default": "NFC"},
+                ),
+                "whitespace": (
+                    [
+                        "Normalize line endings",
+                        "Preserve",
+                        "Collapse horizontal",
+                        "Collapse all",
+                    ],
+                    {"default": "Normalize line endings"},
+                ),
+                "trim_edges": ("BOOLEAN", {"default": True}),
+                "remove_outer_markdown_fence": (
+                    "BOOLEAN",
+                    {"default": False},
+                ),
+                "deduplicate_lines": ("BOOLEAN", {"default": False}),
+                "max_characters": (
+                    "INT",
+                    {
+                        "default": 0,
+                        "min": 0,
+                        "max": 10_000_000,
+                        "tooltip": "0 keeps the complete text.",
+                    },
+                ),
+            }
+        }
+
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("text", "diagnostics_json")
+    FUNCTION = "clean"
+    CATEGORY = TRANSFORM_CATEGORY
+
+    def clean(
+        self,
+        text: str,
+        unicode_normalization: str,
+        whitespace: str,
+        trim_edges: bool,
+        remove_outer_markdown_fence: bool,
+        deduplicate_lines: bool,
+        max_characters: int,
+    ):
+        original = str(text)
+        value = original
+        if unicode_normalization != "None":
+            if unicode_normalization not in {"NFC", "NFKC"}:
+                raise ValueError(
+                    f"Unknown Unicode normalization: {unicode_normalization!r}."
+                )
+            value = unicodedata.normalize(unicode_normalization, value)
+
+        if whitespace != "Preserve":
+            value = value.replace("\r\n", "\n").replace("\r", "\n")
+        if remove_outer_markdown_fence:
+            match = _WHOLE_FENCE.fullmatch(value)
+            if match:
+                value = match.group(1)
+        if whitespace == "Collapse horizontal":
+            value = "\n".join(
+                re.sub(r"[^\S\n]+", " ", line) for line in value.split("\n")
+            )
+        elif whitespace == "Collapse all":
+            value = re.sub(r"\s+", " ", value)
+        elif whitespace not in {"Normalize line endings", "Preserve"}:
+            raise ValueError(f"Unknown whitespace mode: {whitespace!r}.")
+
+        removed_duplicates = 0
+        if deduplicate_lines:
+            seen: set[str] = set()
+            lines = []
+            for line in value.splitlines():
+                key = line.strip()
+                if key and key in seen:
+                    removed_duplicates += 1
+                    continue
+                if key:
+                    seen.add(key)
+                lines.append(line)
+            value = "\n".join(lines)
+        if trim_edges:
+            value = value.strip()
+
+        truncated = int(max_characters) > 0 and len(value) > int(max_characters)
+        if truncated:
+            value = value[: int(max_characters)]
+        diagnostics = {
+            "changed": value != original,
+            "characters_before": len(original),
+            "characters_after": len(value),
+            "duplicate_lines_removed": removed_duplicates,
+            "truncated": truncated,
+        }
+        return value, _json_text(diagnostics)
+
+
+class VLMTextReplace:
+    DESCRIPTION = (
+        "Perform literal or regular-expression replacement with an exact "
+        "replacement count and explicit missing-pattern behavior."
+    )
+    SEARCH_ALIASES = ["find replace", "regex replace", "substitute text"]
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "text": ("STRING", {"default": "", "multiline": True}),
+                "search": ("STRING", {"default": "", "multiline": True}),
+                "replacement": ("STRING", {"default": "", "multiline": True}),
+                "mode": (
+                    ["Literal", "Regular expression"],
+                    {"default": "Literal"},
+                ),
+                "case_sensitive": ("BOOLEAN", {"default": True}),
+                "max_replacements": (
+                    "INT",
+                    {
+                        "default": 0,
+                        "min": 0,
+                        "max": 1_000_000,
+                        "tooltip": "0 replaces every match.",
+                    },
+                ),
+                "if_not_found": (
+                    ["Keep text", "Error"],
+                    {"default": "Keep text"},
+                ),
+            }
+        }
+
+    RETURN_TYPES = ("STRING", "INT", "STRING")
+    RETURN_NAMES = ("text", "replacement_count", "diagnostics_json")
+    FUNCTION = "replace"
+    CATEGORY = TRANSFORM_CATEGORY
+
+    def replace(
+        self,
+        text: str,
+        search: str,
+        replacement: str,
+        mode: str,
+        case_sensitive: bool,
+        max_replacements: int,
+        if_not_found: str,
+    ):
+        value = str(text)
+        if not search:
+            raise ValueError("Search text or regular expression cannot be empty.")
+        limit = int(max_replacements)
+        if mode == "Literal" and case_sensitive:
+            available = value.count(search)
+            count = available if limit == 0 else min(available, limit)
+            output = value.replace(search, replacement, limit if limit else -1)
+        elif mode in {"Literal", "Regular expression"}:
+            pattern = re.escape(search) if mode == "Literal" else search
+            flags = re.MULTILINE | (0 if case_sensitive else re.IGNORECASE)
+            try:
+                output, count = re.subn(
+                    pattern,
+                    replacement,
+                    value,
+                    count=limit,
+                    flags=flags,
+                )
+            except re.error as exc:
+                raise ValueError(f"Invalid regular expression: {exc}.") from exc
+        else:
+            raise ValueError(f"Unknown replacement mode: {mode!r}.")
+
+        if count == 0 and if_not_found == "Error":
+            raise ValueError("The requested search pattern was not found.")
+        if if_not_found not in {"Keep text", "Error"}:
+            raise ValueError(f"Unknown missing-pattern policy: {if_not_found!r}.")
+        diagnostics = {
+            "mode": mode,
+            "case_sensitive": bool(case_sensitive),
+            "replacement_count": count,
+        }
+        return output, count, _json_text(diagnostics)
+
+
+class VLMJSONExtract:
+    DESCRIPTION = (
+        "Safely extract a value using $.dot[0] syntax or RFC 6901 JSON "
+        "Pointer, including JSON embedded in a fenced model response."
+    )
+    SEARCH_ALIASES = ["json path", "json pointer", "extract json field"]
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "text": ("STRING", {"default": "{}", "multiline": True}),
+                "path": (
+                    "STRING",
+                    {
+                        "default": "$",
+                        "placeholder": "$.result.items[0] or /result/items/0",
+                    },
+                ),
+                "output_format": (
+                    ["Text", "Compact JSON", "Pretty JSON"],
+                    {"default": "Text"},
+                ),
+                "if_missing": (
+                    ["Error", "Empty string", "Default value"],
+                    {"default": "Error"},
+                ),
+                "default_value": (
+                    "STRING",
+                    {"default": "", "multiline": True},
+                ),
+            }
+        }
+
+    RETURN_TYPES = ("STRING", "BOOLEAN", "STRING", "STRING")
+    RETURN_NAMES = ("value", "found", "value_type", "canonical_json")
+    FUNCTION = "extract"
+    CATEGORY = JSON_CATEGORY
+
+    def extract(
+        self,
+        text: str,
+        path: str,
+        output_format: str,
+        if_missing: str,
+        default_value: str,
+    ):
+        document = _load_json_document(text)
+        selected = _resolve_json_path(document, path)
+        found = selected is not _MISSING
+        if not found:
+            if if_missing == "Error":
+                raise ValueError(f"JSON path was not found: {path!r}.")
+            if if_missing == "Empty string":
+                selected = ""
+            elif if_missing == "Default value":
+                selected = default_value
+            else:
+                raise ValueError(f"Unknown missing-value policy: {if_missing!r}.")
+
+        if output_format == "Text":
+            output = _display_value(selected)
+        elif output_format == "Compact JSON":
+            output = _json_text(selected)
+        elif output_format == "Pretty JSON":
+            output = _json_text(selected, pretty=True)
+        else:
+            raise ValueError(f"Unknown JSON output format: {output_format!r}.")
+
+        value_type = (
+            "null"
+            if selected is None
+            else "boolean"
+            if isinstance(selected, bool)
+            else "integer"
+            if isinstance(selected, int)
+            else "number"
+            if isinstance(selected, float)
+            else "string"
+            if isinstance(selected, str)
+            else "array"
+            if isinstance(selected, list)
+            else "object"
+            if isinstance(selected, dict)
+            else type(selected).__name__
+        )
+        return output, found, value_type, _json_text(selected)
+
+
+class VLMTextSplit:
+    DESCRIPTION = (
+        "Split text into a real Comfy list for batched execution, with stable "
+        "JSON and count outputs for inspection or API use."
+    )
+    SEARCH_ALIASES = ["text list", "split prompt", "batch strings", "csv to list"]
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "text": ("STRING", {"default": "", "multiline": True}),
+                "mode": (
+                    [
+                        "Lines",
+                        "Paragraphs",
+                        "Literal delimiter",
+                        "Regular expression",
+                        "CSV",
+                        "JSON array",
+                    ],
+                    {"default": "Lines"},
+                ),
+                "delimiter": (
+                    "STRING",
+                    {
+                        "default": ",",
+                        "tooltip": "Used by literal, regex, and CSV modes.",
+                    },
+                ),
+                "trim_items": ("BOOLEAN", {"default": True}),
+                "remove_empty": ("BOOLEAN", {"default": True}),
+                "deduplicate": ("BOOLEAN", {"default": False}),
+                "max_items": (
+                    "INT",
+                    {
+                        "default": 0,
+                        "min": 0,
+                        "max": 100_000,
+                        "tooltip": "0 keeps every item.",
+                    },
+                ),
+            }
+        }
+
+    RETURN_TYPES = ("STRING", "STRING", "INT")
+    RETURN_NAMES = ("items", "items_json", "item_count")
+    OUTPUT_IS_LIST = (True, False, False)
+    FUNCTION = "split"
+    CATEGORY = TRANSFORM_CATEGORY
+
+    def split(
+        self,
+        text: str,
+        mode: str,
+        delimiter: str,
+        trim_items: bool,
+        remove_empty: bool,
+        deduplicate: bool,
+        max_items: int,
+    ):
+        value = str(text)
+        if mode == "Lines":
+            items = value.splitlines()
+        elif mode == "Paragraphs":
+            items = re.split(r"\n\s*\n+", value)
+        elif mode == "Literal delimiter":
+            if not delimiter:
+                raise ValueError("Literal delimiter cannot be empty.")
+            items = value.split(delimiter)
+        elif mode == "Regular expression":
+            if not delimiter:
+                raise ValueError("Regular-expression delimiter cannot be empty.")
+            try:
+                items = re.split(delimiter, value)
+            except re.error as exc:
+                raise ValueError(f"Invalid regular expression: {exc}.") from exc
+        elif mode == "CSV":
+            if len(delimiter) != 1:
+                raise ValueError("CSV delimiter must be exactly one character.")
+            items = [
+                cell
+                for row in csv.reader(io.StringIO(value), delimiter=delimiter)
+                for cell in row
+            ]
+        elif mode == "JSON array":
+            parsed = _load_json_document(value)
+            if not isinstance(parsed, list):
+                raise ValueError("JSON array mode requires a top-level array.")
+            items = [_display_value(item) for item in parsed]
+        else:
+            raise ValueError(f"Unknown split mode: {mode!r}.")
+
+        items = [str(item) for item in items]
+        if trim_items:
+            items = [item.strip() for item in items]
+        if remove_empty:
+            items = [item for item in items if item]
+        if deduplicate:
+            items = list(dict.fromkeys(items))
+        if int(max_items) > 0:
+            items = items[: int(max_items)]
+        return items, _json_text(items), len(items)
+
+
+class VLMTextInspect:
+    DESCRIPTION = (
+        "Pass text through while reporting deterministic size, line, word, "
+        "rough token-budget, and SHA-256 metadata without network calls."
+    )
+    SEARCH_ALIASES = ["text stats", "count words", "string hash", "prompt size"]
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "text": ("STRING", {"default": "", "multiline": True}),
+            }
+        }
+
+    RETURN_TYPES = (
+        "STRING",
+        "INT",
+        "INT",
+        "INT",
+        "INT",
+        "INT",
+        "STRING",
+        "STRING",
+    )
+    RETURN_NAMES = (
+        "text",
+        "characters",
+        "utf8_bytes",
+        "words",
+        "lines",
+        "approx_tokens",
+        "sha256",
+        "stats_json",
+    )
+    FUNCTION = "inspect"
+    CATEGORY = INSPECT_CATEGORY
+
+    def inspect(self, text: str):
+        value = str(text)
+        metrics = _metrics(value)
+        return (
+            value,
+            metrics["characters"],
+            metrics["utf8_bytes"],
+            metrics["words"],
+            metrics["lines"],
+            metrics["approx_tokens"],
+            metrics["sha256"],
+            _json_text(metrics),
+        )
+
+
+NODE_CLASS_MAPPINGS = {
+    "SimpleText": SimpleText,
+    "JsonToText": JsonToText,
+    "ViewText": ViewText,
+    "VLMTextJoin": VLMTextJoin,
+    "VLMTextTemplate": VLMTextTemplate,
+    "VLMTextClean": VLMTextClean,
+    "VLMTextReplace": VLMTextReplace,
+    "VLMJSONExtract": VLMJSONExtract,
+    "VLMTextSplit": VLMTextSplit,
+    "VLMTextInspect": VLMTextInspect,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "SimpleText": "Text",
+    "JsonToText": "JSON to Text",
+    "ViewText": "View Text (Streaming)",
+    "VLMTextJoin": "Text Join",
+    "VLMTextTemplate": "Text Template",
+    "VLMTextClean": "Text Clean",
+    "VLMTextReplace": "Text Replace",
+    "VLMJSONExtract": "JSON Extract",
+    "VLMTextSplit": "Text Split / Batch",
+    "VLMTextInspect": "Text Inspector",
+}

--- a/nodes/uform.py
+++ b/nodes/uform.py
@@ -105,7 +105,7 @@ class UformGen2QwenNode(CachedModelNode):
 
     RETURN_TYPES = ("STRING",)
     FUNCTION = "uform_gen2_qwen_chat"
-    CATEGORY = "VLM Nodes/UformGen2Qwen"
+    CATEGORY = "VLM Nodes/Legacy/Model Loaders"
 
     def uform_gen2_qwen_chat(
         self, image, question, max_new_tokens=512, unload_after=False

--- a/nodes/video_intelligence.py
+++ b/nodes/video_intelligence.py
@@ -1,0 +1,1310 @@
+"""Fast temporal video understanding built from reusable perception signals.
+
+The VLM is intentionally kept out of the per-frame loop.  This module selects
+information-rich frames, preserves their real source timestamps, creates
+track-aware semantic crops, and converts structured VLM responses into the
+canonical temporal event and scene-state payloads.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import time
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+from .geometry import box_center, clip_box
+from .modern_vlm import (
+    ATTENTION_MODES,
+    MEMORY_MODES,
+    RECOMMENDED_MODEL_LABELS,
+    ModernVLM,
+)
+from .vision_types import (
+    VLM_EVENTS,
+    VLM_SCENE_STATE,
+    VLM_TRACKS,
+    VLM_VIDEO_SELECTION,
+    EventSequence,
+    SceneObjectState,
+    SceneState,
+    SelectedVideoFrame,
+    TemporalEvent,
+    TrackSequence,
+    VideoFrameSelection,
+)
+
+SAMPLING_STRATEGIES = (
+    "Hybrid: scene + motion + tracks",
+    "Uniform coverage",
+    "Motion priority",
+    "Scene-change priority",
+    "Track-change priority",
+)
+
+VIDEO_TASKS = (
+    "Action timeline",
+    "Robotics scene understanding",
+    "Safety and anomaly monitor",
+    "Detailed temporal summary",
+    "Answer a question",
+)
+
+VIDEO_REASONING_JSON_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["summary", "events"],
+    "properties": {
+        "summary": {"type": "string"},
+        "events": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": [
+                    "start_time",
+                    "end_time",
+                    "label",
+                    "text",
+                    "score",
+                    "evidence_frame_indices",
+                ],
+                "properties": {
+                    "start_time": {"type": "number", "minimum": 0},
+                    "end_time": {"type": "number", "minimum": 0},
+                    "label": {"type": "string"},
+                    "text": {"type": "string"},
+                    "score": {"type": "number", "minimum": 0, "maximum": 1},
+                    "evidence_frame_indices": {
+                        "type": "array",
+                        "items": {"type": "integer", "minimum": 0},
+                        "uniqueItems": True,
+                    },
+                },
+            },
+        },
+    },
+}
+
+
+def _video_tensor(frames: Any) -> torch.Tensor:
+    if not isinstance(frames, torch.Tensor):
+        raise TypeError("frames must be a ComfyUI IMAGE tensor.")
+    if frames.ndim != 4 or frames.shape[-1] not in (3, 4):
+        raise ValueError("frames must have shape [frames, height, width, 3|4].")
+    if frames.shape[0] < 1 or frames.shape[1] < 1 or frames.shape[2] < 1:
+        raise ValueError("frames must contain at least one non-empty image.")
+    if not frames.dtype.is_floating_point:
+        raise TypeError("ComfyUI IMAGE tensors must use a floating-point dtype.")
+    if not bool(torch.isfinite(frames).all().item()):
+        raise ValueError("frames contain NaN or infinite values.")
+    return frames
+
+
+def _positive_fps(value: Any) -> float:
+    fps = float(value)
+    if not math.isfinite(fps) or fps <= 0:
+        raise ValueError("fps must be a positive finite number.")
+    return fps
+
+
+def _robust_unit(values: torch.Tensor) -> torch.Tensor:
+    values = values.detach().to(device="cpu", dtype=torch.float32)
+    if values.numel() == 0:
+        return values
+    low = torch.quantile(values, 0.05)
+    high = torch.quantile(values, 0.95)
+    span = high - low
+    if float(span) <= 1.0e-8:
+        return torch.zeros_like(values)
+    return ((values - low) / span).clamp(0, 1)
+
+
+def _visual_signals(
+    frames: torch.Tensor,
+    *,
+    thumbnail_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return normalized per-frame motion and coarse scene-change scores."""
+
+    rgb = (
+        frames[..., :3]
+        .detach()
+        .to(dtype=torch.float32)
+        .movedim(-1, 1)
+        .clamp(0, 1)
+    )
+    side = min(int(thumbnail_size), int(frames.shape[1]), int(frames.shape[2]))
+    thumbnails = F.interpolate(
+        rgb,
+        size=(side, side),
+        mode="bilinear",
+        align_corners=False,
+        antialias=True,
+    )
+    gray = (
+        thumbnails[:, 0] * 0.299
+        + thumbnails[:, 1] * 0.587
+        + thumbnails[:, 2] * 0.114
+    )
+    frame_count = int(frames.shape[0])
+    motion_raw = torch.zeros(frame_count, device=gray.device)
+    scene_raw = torch.zeros(frame_count, device=gray.device)
+    if frame_count > 1:
+        centered = gray - gray.mean(dim=(1, 2), keepdim=True)
+        structural_delta = (centered[1:] - centered[:-1]).abs().mean(dim=(1, 2))
+        color_mean = thumbnails.mean(dim=(2, 3))
+        color_std = thumbnails.std(dim=(2, 3), unbiased=False)
+        appearance_delta = (color_mean[1:] - color_mean[:-1]).abs().mean(dim=1)
+        appearance_delta += (
+            color_std[1:] - color_std[:-1]
+        ).abs().mean(dim=1)
+        motion_raw[1:] = structural_delta
+        scene_raw[1:] = structural_delta * 0.55 + appearance_delta * 0.45
+    return _robust_unit(motion_raw), _robust_unit(scene_raw)
+
+
+def _observed_detection(detection: Any) -> bool:
+    state = detection.metadata.get("track_state")
+    return state not in {"lost", "removed", "predicted"}
+
+
+def _track_change_signal(
+    tracks: TrackSequence | None,
+    *,
+    frame_count: int,
+    width: int,
+    height: int,
+) -> torch.Tensor:
+    signal = torch.zeros(frame_count, dtype=torch.float32)
+    if tracks is None:
+        return signal
+    if not isinstance(tracks, TrackSequence):
+        raise TypeError("tracks must be a VLM Track Sequence.")
+    if tracks.width != width or tracks.height != height:
+        raise ValueError("Track dimensions must match the video frames.")
+    diagonal = max(math.hypot(width, height), 1.0)
+    for track in tracks.tracks:
+        observed = sorted(
+            (
+                detection
+                for detection in track.detections
+                if _observed_detection(detection)
+                and 0 <= detection.frame_index < frame_count
+            ),
+            key=lambda detection: detection.frame_index,
+        )
+        if not observed:
+            continue
+        signal[observed[0].frame_index] += 1.0
+        if len(observed) > 1:
+            signal[observed[-1].frame_index] += 0.75
+        previous = observed[0]
+        for current in observed[1:]:
+            first_center = box_center(previous.bbox_xyxy)
+            second_center = box_center(current.bbox_xyxy)
+            displacement = math.hypot(
+                second_center[0] - first_center[0],
+                second_center[1] - first_center[1],
+            )
+            signal[current.frame_index] += min(1.0, displacement / diagonal * 8.0)
+            previous = current
+    return _robust_unit(signal)
+
+
+def _uniform_indices(frame_count: int, count: int) -> list[int]:
+    if count >= frame_count:
+        return list(range(frame_count))
+    if count <= 1:
+        return [0]
+    return sorted(
+        {
+            round(index * (frame_count - 1) / (count - 1))
+            for index in range(count)
+        }
+    )
+
+
+def _sampling_weights(strategy: str) -> tuple[float, float, float]:
+    if strategy == "Uniform coverage":
+        return 0.0, 0.0, 0.0
+    if strategy == "Motion priority":
+        return 0.75, 0.20, 0.05
+    if strategy == "Scene-change priority":
+        return 0.20, 0.75, 0.05
+    if strategy == "Track-change priority":
+        return 0.15, 0.15, 0.70
+    if strategy == "Hybrid: scene + motion + tracks":
+        return 0.40, 0.35, 0.25
+    raise ValueError(f"Unsupported sampling strategy {strategy!r}.")
+
+
+def sample_video_frames(
+    frames: torch.Tensor,
+    *,
+    fps: float,
+    max_frames: int,
+    strategy: str = "Hybrid: scene + motion + tracks",
+    minimum_gap_seconds: float = 0.15,
+    thumbnail_size: int = 96,
+    tracks: TrackSequence | None = None,
+) -> tuple[torch.Tensor, VideoFrameSelection, dict[str, Any]]:
+    """Select a bounded, timestamped frame batch without mutating the source."""
+
+    frames = _video_tensor(frames)
+    fps = _positive_fps(fps)
+    frame_count, height, width = map(int, frames.shape[:3])
+    max_frames = int(max_frames)
+    if max_frames < 1:
+        raise ValueError("max_frames must be at least 1.")
+    max_frames = min(max_frames, frame_count)
+    minimum_gap_seconds = float(minimum_gap_seconds)
+    if not math.isfinite(minimum_gap_seconds) or minimum_gap_seconds < 0:
+        raise ValueError("minimum_gap_seconds must be finite and non-negative.")
+    thumbnail_size = int(thumbnail_size)
+    if not 16 <= thumbnail_size <= 256:
+        raise ValueError("thumbnail_size must be between 16 and 256.")
+
+    started = time.perf_counter()
+    if strategy == "Uniform coverage" or frame_count == 1:
+        motion = torch.zeros(frame_count)
+        scene = torch.zeros(frame_count)
+    else:
+        motion, scene = _visual_signals(
+            frames,
+            thumbnail_size=thumbnail_size,
+        )
+    track_signal = _track_change_signal(
+        tracks,
+        frame_count=frame_count,
+        width=width,
+        height=height,
+    )
+    motion_weight, scene_weight, track_weight = _sampling_weights(strategy)
+    combined = (
+        motion * motion_weight
+        + scene * scene_weight
+        + track_signal * track_weight
+    ).clamp(0, 1)
+
+    if max_frames >= frame_count:
+        selected = list(range(frame_count))
+        coverage_anchors = set(selected)
+    elif strategy == "Uniform coverage":
+        selected = _uniform_indices(frame_count, max_frames)
+        coverage_anchors = set(selected)
+    else:
+        anchor_count = min(
+            max_frames,
+            max(2 if max_frames > 1 else 1, round(max_frames * 0.35)),
+        )
+        coverage_anchors = set(_uniform_indices(frame_count, anchor_count))
+        selected_set = set(coverage_anchors)
+        if max_frames > 1:
+            selected_set.update((0, frame_count - 1))
+        gap_frames = max(1, round(minimum_gap_seconds * fps))
+        candidates = sorted(
+            range(frame_count),
+            key=lambda index: (-float(combined[index]), index),
+        )
+        for candidate in candidates:
+            if len(selected_set) >= max_frames:
+                break
+            if all(abs(candidate - existing) >= gap_frames for existing in selected_set):
+                selected_set.add(candidate)
+        if len(selected_set) < max_frames:
+            for candidate in candidates:
+                if len(selected_set) >= max_frames:
+                    break
+                selected_set.add(candidate)
+        selected = sorted(selected_set)[:max_frames]
+
+    records = []
+    for index in selected:
+        reasons = []
+        if index == 0:
+            reasons.append("first-frame")
+        if index == frame_count - 1 and frame_count > 1:
+            reasons.append("last-frame")
+        if index in coverage_anchors:
+            reasons.append("coverage")
+        if float(scene[index]) >= 0.55:
+            reasons.append("scene-change")
+        if float(motion[index]) >= 0.55:
+            reasons.append("motion")
+        if float(track_signal[index]) >= 0.45:
+            reasons.append("track-change")
+        if not reasons:
+            reasons.append("best-available")
+        score = (
+            1.0
+            if index in {0, frame_count - 1}
+            else max(float(combined[index]), 0.05 if index in coverage_anchors else 0.0)
+        )
+        records.append(
+            SelectedVideoFrame(
+                source_frame_index=index,
+                timestamp=index / fps,
+                score=min(1.0, score),
+                reasons=tuple(reasons),
+            )
+        )
+
+    elapsed_ms = (time.perf_counter() - started) * 1000
+    selection = VideoFrameSelection(
+        width=width,
+        height=height,
+        source_frame_count=frame_count,
+        fps=fps,
+        frames=tuple(records),
+        strategy=strategy,
+        source="ComfyUI IMAGE batch",
+        metadata={
+            "minimum_gap_seconds": minimum_gap_seconds,
+            "thumbnail_size": thumbnail_size,
+            "weights": {
+                "motion": motion_weight,
+                "scene": scene_weight,
+                "tracks": track_weight,
+            },
+        },
+    )
+    diagnostics = {
+        "source_frames": frame_count,
+        "selected_frames": len(selected),
+        "visual_reduction_ratio": 1.0 - len(selected) / frame_count,
+        "sampling_ms": elapsed_ms,
+        "strategy": strategy,
+        "indices": selected,
+        "timestamps": [record.timestamp for record in records],
+        "motion_peak": float(motion.max()) if motion.numel() else 0.0,
+        "scene_peak": float(scene.max()) if scene.numel() else 0.0,
+        "track_peak": float(track_signal.max()) if track_signal.numel() else 0.0,
+    }
+    index_tensor = torch.tensor(selected, dtype=torch.long, device=frames.device)
+    return frames.index_select(0, index_tensor), selection, diagnostics
+
+
+def resize_video_for_analysis(
+    frames: torch.Tensor,
+    *,
+    max_side: int,
+) -> torch.Tensor:
+    """Downscale a sampled batch once while preserving aspect ratio and range."""
+
+    frames = _video_tensor(frames)
+    max_side = int(max_side)
+    if max_side == 0:
+        return frames
+    if not 128 <= max_side <= 4096:
+        raise ValueError("analysis max_side must be 0 or between 128 and 4096.")
+    height, width = map(int, frames.shape[1:3])
+    current_max = max(height, width)
+    if current_max <= max_side:
+        return frames
+    scale = max_side / current_max
+    target_height = max(1, round(height * scale))
+    target_width = max(1, round(width * scale))
+    resized = F.interpolate(
+        frames[..., :3].movedim(-1, 1).to(dtype=torch.float32),
+        size=(target_height, target_width),
+        mode="bilinear",
+        align_corners=False,
+        antialias=True,
+    )
+    return resized.movedim(1, -1).clamp(0, 1)
+
+
+def _letterbox_crop(
+    frame: torch.Tensor,
+    box: Sequence[float],
+    *,
+    output_size: int,
+    context_scale: float,
+) -> tuple[torch.Tensor, tuple[int, int, int, int]]:
+    height, width = map(int, frame.shape[:2])
+    x1, y1, x2, y2 = clip_box(box, width, height)
+    center_x = (x1 + x2) * 0.5
+    center_y = (y1 + y2) * 0.5
+    crop_width = max(2.0, (x2 - x1) * context_scale)
+    crop_height = max(2.0, (y2 - y1) * context_scale)
+    left = max(0, math.floor(center_x - crop_width * 0.5))
+    top = max(0, math.floor(center_y - crop_height * 0.5))
+    right = min(width, math.ceil(center_x + crop_width * 0.5))
+    bottom = min(height, math.ceil(center_y + crop_height * 0.5))
+    if right <= left or bottom <= top:
+        raise ValueError("A tracked detection produced an empty crop.")
+    crop = frame[top:bottom, left:right, :3].movedim(-1, 0).unsqueeze(0)
+    scale = min(output_size / crop.shape[-1], output_size / crop.shape[-2])
+    resized_width = max(1, round(crop.shape[-1] * scale))
+    resized_height = max(1, round(crop.shape[-2] * scale))
+    resized = F.interpolate(
+        crop.to(dtype=torch.float32),
+        size=(resized_height, resized_width),
+        mode="bilinear",
+        align_corners=False,
+        antialias=True,
+    )
+    canvas = torch.zeros(
+        (1, 3, output_size, output_size),
+        dtype=resized.dtype,
+        device=resized.device,
+    )
+    x_offset = (output_size - resized_width) // 2
+    y_offset = (output_size - resized_height) // 2
+    canvas[
+        :,
+        :,
+        y_offset : y_offset + resized_height,
+        x_offset : x_offset + resized_width,
+    ] = resized
+    return canvas[0].movedim(0, -1), (left, top, right, bottom)
+
+
+def track_aware_crops(
+    frames: torch.Tensor,
+    tracks: TrackSequence,
+    *,
+    crops_per_track: int,
+    max_crops: int,
+    output_size: int,
+    context_scale: float,
+) -> tuple[torch.Tensor, list[dict[str, Any]]]:
+    frames = _video_tensor(frames)
+    if not isinstance(tracks, TrackSequence):
+        raise TypeError("tracks must be a VLM Track Sequence.")
+    if tracks.width != frames.shape[2] or tracks.height != frames.shape[1]:
+        raise ValueError("Track dimensions must match the video frames.")
+    crops_per_track = int(crops_per_track)
+    max_crops = int(max_crops)
+    output_size = int(output_size)
+    context_scale = float(context_scale)
+    if not 1 <= crops_per_track <= 16:
+        raise ValueError("crops_per_track must be between 1 and 16.")
+    if not 1 <= max_crops <= 256:
+        raise ValueError("max_crops must be between 1 and 256.")
+    if not 64 <= output_size <= 2048:
+        raise ValueError("output_size must be between 64 and 2048.")
+    if not 1.0 <= context_scale <= 4.0:
+        raise ValueError("context_scale must be between 1 and 4.")
+
+    candidates = []
+    for track in tracks.tracks:
+        observed = sorted(
+            (
+                detection
+                for detection in track.detections
+                if _observed_detection(detection)
+                and detection.frame_index < frames.shape[0]
+            ),
+            key=lambda detection: detection.frame_index,
+        )
+        if not observed:
+            continue
+        positions = _uniform_indices(len(observed), min(crops_per_track, len(observed)))
+        for position in positions:
+            detection = observed[position]
+            candidates.append((track, detection))
+    candidates = candidates[:max_crops]
+    if not candidates:
+        raise ValueError("No observed track detections are available for cropping.")
+
+    crops = []
+    manifest = []
+    for crop_index, (track, detection) in enumerate(candidates):
+        crop, crop_bounds = _letterbox_crop(
+            frames[detection.frame_index],
+            detection.bbox_xyxy,
+            output_size=output_size,
+            context_scale=context_scale,
+        )
+        crops.append(crop)
+        manifest.append(
+            {
+                "crop_index": crop_index,
+                "track_id": track.track_id,
+                "label": track.label or detection.label,
+                "source_frame_index": detection.frame_index,
+                "timestamp": detection.timestamp,
+                "detection_bbox_xyxy": list(detection.bbox_xyxy),
+                "crop_bounds_xyxy": list(crop_bounds),
+            }
+        )
+    return torch.stack(crops), manifest
+
+
+def _track_label(track: Any, observed: Sequence[Any]) -> str | None:
+    if track.label:
+        return track.label
+    labels = [detection.label for detection in observed if detection.label]
+    return Counter(labels).most_common(1)[0][0] if labels else None
+
+
+def build_scene_state(
+    tracks: TrackSequence,
+    events: EventSequence | None = None,
+) -> SceneState:
+    if not isinstance(tracks, TrackSequence):
+        raise TypeError("tracks must be a VLM Track Sequence.")
+    if events is not None and not isinstance(events, EventSequence):
+        raise TypeError("events must be a VLM Event Sequence.")
+    objects = []
+    for track in tracks.tracks:
+        observed = sorted(
+            (
+                detection
+                for detection in track.detections
+                if _observed_detection(detection)
+            ),
+            key=lambda detection: (detection.timestamp, detection.frame_index),
+        )
+        if not observed:
+            continue
+        first, last = observed[0], observed[-1]
+        elapsed = last.timestamp - first.timestamp
+        if elapsed > 1.0e-6:
+            first_center = box_center(first.bbox_xyxy)
+            last_center = box_center(last.bbox_xyxy)
+            velocity = (
+                (last_center[0] - first_center[0]) / elapsed,
+                (last_center[1] - first_center[1]) / elapsed,
+            )
+        else:
+            velocity = (0.0, 0.0)
+        scores = [
+            detection.score
+            for detection in observed
+            if detection.score is not None
+        ]
+        latest_state = last.metadata.get("track_state")
+        state = (
+            latest_state
+            if isinstance(latest_state, str) and latest_state
+            else track.metadata.get("state", "active")
+        )
+        objects.append(
+            SceneObjectState(
+                track_id=track.track_id,
+                label=_track_label(track, observed),
+                first_seen=first.timestamp,
+                last_seen=last.timestamp,
+                last_bbox_xyxy=last.bbox_xyxy,
+                observation_count=len(observed),
+                mean_confidence=(
+                    sum(scores) / len(scores) if scores else track.score
+                ),
+                velocity_xy_px_s=velocity,
+                state=str(state),
+                metadata={
+                    "first_frame": first.frame_index,
+                    "last_frame": last.frame_index,
+                    "trajectory_samples": len(track.detections),
+                },
+            )
+        )
+    return SceneState(
+        width=tracks.width,
+        height=tracks.height,
+        frame_count=tracks.frame_count,
+        fps=tracks.fps,
+        objects=tuple(sorted(objects, key=lambda item: item.track_id)),
+        events=events.events if events is not None else (),
+        source="VLM persistent scene state",
+        metadata={
+            "tracker_source": tracks.source,
+            "track_count": len(tracks.tracks),
+            "observed_object_count": len(objects),
+        },
+    )
+
+
+def scene_state_summary(scene: SceneState) -> str:
+    lines = [
+        (
+            f"Scene: {scene.width}x{scene.height}, {scene.frame_count} frames, "
+            f"{scene.fps:g} FPS."
+            if scene.fps is not None
+            else f"Scene: {scene.width}x{scene.height}, {scene.frame_count} frames."
+        )
+    ]
+    for item in scene.objects:
+        label = item.label or "object"
+        vx, vy = item.velocity_xy_px_s
+        lines.append(
+            f"#{item.track_id} {label}: {item.state}; "
+            f"{item.first_seen:.3f}s–{item.last_seen:.3f}s; "
+            f"{item.observation_count} observations; "
+            f"velocity=({vx:.1f}, {vy:.1f}) px/s."
+        )
+    for event in scene.events:
+        lines.append(
+            f"Event {event.start_time:.3f}s–{event.end_time:.3f}s: "
+            f"{event.label or event.text or 'event'}."
+        )
+    return "\n".join(lines)
+
+
+def build_video_reasoning_prompt(
+    selection: VideoFrameSelection,
+    *,
+    task: str,
+    question: str,
+    max_events: int,
+    scene_state: SceneState | None = None,
+) -> str:
+    if not isinstance(selection, VideoFrameSelection):
+        raise TypeError("selection must be a VLM Video Selection.")
+    if task not in VIDEO_TASKS:
+        raise ValueError(f"Unsupported video reasoning task {task!r}.")
+    max_events = int(max_events)
+    if not 1 <= max_events <= 256:
+        raise ValueError("max_events must be between 1 and 256.")
+    question = str(question).strip()
+    if task == "Answer a question" and not question:
+        raise ValueError("A question is required for the question-answering task.")
+    mapping = "\n".join(
+        f"- supplied image {position}: source frame "
+        f"{frame.source_frame_index}, timestamp {frame.timestamp:.6f}s"
+        for position, frame in enumerate(selection.frames)
+    )
+    task_guidance = {
+        "Action timeline": (
+            "Identify observable actions and changes in chronological order. "
+            "Do not invent events between evidence frames."
+        ),
+        "Robotics scene understanding": (
+            "Describe agents, manipulated objects, spatial relations, motion, "
+            "object permanence, affordances, and uncertainty. Do not propose "
+            "motor commands."
+        ),
+        "Safety and anomaly monitor": (
+            "Identify only visible hazards, unsafe interactions, anomalies, "
+            "and state changes. State uncertainty explicitly."
+        ),
+        "Detailed temporal summary": (
+            "Summarize the scene and its temporal progression with precise "
+            "timestamps and stable identities."
+        ),
+        "Answer a question": (
+            f"Answer this question using only visible evidence: {question}"
+        ),
+    }[task]
+    state_context = (
+        "\nKnown track-derived scene state:\n" + scene_state_summary(scene_state)
+        if scene_state is not None
+        else ""
+    )
+    schema = json.dumps(
+        VIDEO_REASONING_JSON_SCHEMA,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    return (
+        "Analyze the sampled frames from one video. The samples are irregularly "
+        "spaced; never assume adjacent supplied images are adjacent source frames.\n"
+        f"Source video: {selection.source_frame_count} frames at "
+        f"{selection.fps:g} FPS, duration {selection.duration:.6f}s.\n"
+        f"Frame mapping:\n{mapping}{state_context}\n\n"
+        f"Task: {task_guidance}\n"
+        f"Return at most {max_events} non-overlapping or meaningfully overlapping "
+        "events. Use seconds on the source timeline. evidence_frame_indices must "
+        "contain only source frame indices listed above. Scores express confidence "
+        "in visible evidence, not importance. If no event is supported, return an "
+        "empty events array. Output one JSON object only: no Markdown and no prose "
+        "outside JSON.\n"
+        f"JSON Schema:\n{schema}"
+    )
+
+
+def _first_json_object(text: str) -> Mapping[str, Any]:
+    if not isinstance(text, str) or not text.strip():
+        raise ValueError("The VLM response is empty.")
+    decoder = json.JSONDecoder()
+    for index, character in enumerate(text):
+        if character != "{":
+            continue
+        try:
+            value, _end = decoder.raw_decode(text[index:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, Mapping):
+            return value
+    raise ValueError("The VLM response does not contain a valid JSON object.")
+
+
+def parse_video_reasoning_output(
+    text: str,
+    selection: VideoFrameSelection,
+    *,
+    max_events: int = 256,
+) -> tuple[str, EventSequence, str]:
+    if not isinstance(selection, VideoFrameSelection):
+        raise TypeError("selection must be a VLM Video Selection.")
+    value = _first_json_object(text)
+    summary = value.get("summary")
+    if not isinstance(summary, str) or not summary.strip():
+        raise ValueError("Structured video output requires a non-empty summary.")
+    raw_events = value.get("events")
+    if not isinstance(raw_events, list):
+        raise ValueError("Structured video output events must be an array.")
+    if len(raw_events) > int(max_events):
+        raise ValueError(f"Structured video output exceeds {int(max_events)} events.")
+    allowed_indices = set(selection.indices)
+    parsed = []
+    for index, item in enumerate(raw_events):
+        if not isinstance(item, Mapping):
+            raise TypeError(f"Event {index} must be a JSON object.")
+        try:
+            start = float(item["start_time"])
+            end = float(item["end_time"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(f"Event {index} has invalid timestamps.") from exc
+        if (
+            not math.isfinite(start)
+            or not math.isfinite(end)
+            or start < 0
+            or end < start
+            or end > selection.duration + 1.0e-6
+        ):
+            raise ValueError(f"Event {index} lies outside the source timeline.")
+        label = item.get("label")
+        text_value = item.get("text")
+        if label is not None and not isinstance(label, str):
+            raise TypeError(f"Event {index} label must be a string.")
+        if text_value is not None and not isinstance(text_value, str):
+            raise TypeError(f"Event {index} text must be a string.")
+        if not (label and label.strip()) and not (text_value and text_value.strip()):
+            raise ValueError(f"Event {index} requires a label or description.")
+        raw_score = item.get("score")
+        score = None if raw_score is None else float(raw_score)
+        if score is not None and (
+            not math.isfinite(score) or not 0.0 <= score <= 1.0
+        ):
+            raise ValueError(f"Event {index} score must be between 0 and 1.")
+        evidence = item.get("evidence_frame_indices", [])
+        if not isinstance(evidence, list) or any(
+            not isinstance(frame_index, int) for frame_index in evidence
+        ):
+            raise TypeError(
+                f"Event {index} evidence_frame_indices must contain integers."
+            )
+        if len(evidence) != len(set(evidence)):
+            raise ValueError(f"Event {index} contains duplicate evidence frames.")
+        invalid_evidence = sorted(set(evidence) - allowed_indices)
+        evidence_mode = "source-frame-index"
+        if invalid_evidence:
+            if all(0 <= frame_index < len(selection.frames) for frame_index in evidence):
+                evidence = [
+                    selection.frames[position].source_frame_index
+                    for position in evidence
+                ]
+                evidence_mode = "supplied-image-position"
+            else:
+                raise ValueError(
+                    f"Event {index} references frames that were not supplied "
+                    "to the VLM."
+                )
+        parsed.append(
+            TemporalEvent(
+                start_time=start,
+                end_time=end,
+                label=label.strip() if isinstance(label, str) and label.strip() else None,
+                text=(
+                    text_value.strip()
+                    if isinstance(text_value, str) and text_value.strip()
+                    else None
+                ),
+                score=score,
+                source="video-vlm",
+                metadata={
+                    "evidence_frame_indices": evidence,
+                    "evidence_index_mode": evidence_mode,
+                },
+            )
+        )
+    parsed.sort(key=lambda event: (event.start_time, event.end_time))
+    events = EventSequence(
+        events=tuple(parsed),
+        duration=selection.duration,
+        source="video-vlm",
+        metadata={
+            "source_frame_count": selection.source_frame_count,
+            "sampled_frame_count": len(selection.frames),
+            "sampling_strategy": selection.strategy,
+        },
+    )
+    normalized = json.dumps(
+        {
+            "summary": summary.strip(),
+            "events": [event.to_dict() for event in events.events],
+        },
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        indent=2,
+    )
+    return summary.strip(), events, normalized
+
+
+class VLMAdaptiveFrameSampler:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "frames": ("IMAGE",),
+                "fps": (
+                    "FLOAT",
+                    {"default": 24.0, "min": 0.01, "max": 1000.0, "step": 0.01},
+                ),
+                "max_frames": (
+                    "INT",
+                    {"default": 16, "min": 1, "max": 512},
+                ),
+                "strategy": (
+                    SAMPLING_STRATEGIES,
+                    {"default": "Hybrid: scene + motion + tracks"},
+                ),
+                "minimum_gap_seconds": (
+                    "FLOAT",
+                    {"default": 0.15, "min": 0.0, "max": 60.0, "step": 0.01},
+                ),
+                "thumbnail_size": (
+                    "INT",
+                    {"default": 96, "min": 16, "max": 256, "step": 16},
+                ),
+            },
+            "optional": {"tracks": (VLM_TRACKS,)},
+        }
+
+    RETURN_TYPES = ("IMAGE", VLM_VIDEO_SELECTION, "STRING", "STRING")
+    RETURN_NAMES = (
+        "sampled_frames",
+        "selection",
+        "selection_json",
+        "diagnostics_json",
+    )
+    FUNCTION = "sample"
+    CATEGORY = "VLM Nodes/Video Intelligence"
+
+    def sample(
+        self,
+        frames,
+        fps,
+        max_frames,
+        strategy,
+        minimum_gap_seconds,
+        thumbnail_size,
+        tracks=None,
+    ):
+        sampled, selection, diagnostics = sample_video_frames(
+            frames,
+            fps=fps,
+            max_frames=max_frames,
+            strategy=strategy,
+            minimum_gap_seconds=minimum_gap_seconds,
+            thumbnail_size=thumbnail_size,
+            tracks=tracks,
+        )
+        return (
+            sampled,
+            selection,
+            selection.to_json(indent=2),
+            json.dumps(diagnostics, indent=2, sort_keys=True),
+        )
+
+
+class VLMTrackAwareCrops:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "frames": ("IMAGE",),
+                "tracks": (VLM_TRACKS,),
+                "crops_per_track": (
+                    "INT",
+                    {"default": 3, "min": 1, "max": 16},
+                ),
+                "max_crops": (
+                    "INT",
+                    {"default": 32, "min": 1, "max": 256},
+                ),
+                "output_size": (
+                    "INT",
+                    {"default": 448, "min": 64, "max": 2048, "step": 32},
+                ),
+                "context_scale": (
+                    "FLOAT",
+                    {"default": 1.35, "min": 1.0, "max": 4.0, "step": 0.05},
+                ),
+            }
+        }
+
+    RETURN_TYPES = ("IMAGE", "STRING")
+    RETURN_NAMES = ("crops", "crop_manifest_json")
+    FUNCTION = "crop"
+    CATEGORY = "VLM Nodes/Video Intelligence"
+
+    def crop(
+        self,
+        frames,
+        tracks,
+        crops_per_track,
+        max_crops,
+        output_size,
+        context_scale,
+    ):
+        crops, manifest = track_aware_crops(
+            frames,
+            tracks,
+            crops_per_track=crops_per_track,
+            max_crops=max_crops,
+            output_size=output_size,
+            context_scale=context_scale,
+        )
+        return (
+            crops,
+            json.dumps(
+                {"schema": "comfyui-vlm/track-crops", "crops": manifest},
+                indent=2,
+                sort_keys=True,
+            ),
+        )
+
+
+class VLMBuildSceneState:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {"tracks": (VLM_TRACKS,)},
+            "optional": {"events": (VLM_EVENTS,)},
+        }
+
+    RETURN_TYPES = (VLM_SCENE_STATE, "STRING", "STRING")
+    RETURN_NAMES = ("scene_state", "scene_state_json", "summary")
+    FUNCTION = "build"
+    CATEGORY = "VLM Nodes/Video Intelligence"
+
+    def build(self, tracks, events=None):
+        scene = build_scene_state(tracks, events)
+        return scene, scene.to_json(indent=2), scene_state_summary(scene)
+
+
+class VLMVideoReasoningPrompt:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "selection": (VLM_VIDEO_SELECTION,),
+                "task": (VIDEO_TASKS, {"default": "Action timeline"}),
+                "question": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "What changes over time?",
+                    },
+                ),
+                "max_events": (
+                    "INT",
+                    {"default": 24, "min": 1, "max": 256},
+                ),
+            },
+            "optional": {"scene_state": (VLM_SCENE_STATE,)},
+        }
+
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("prompt", "json_schema")
+    FUNCTION = "build"
+    CATEGORY = "VLM Nodes/Video Intelligence"
+
+    def build(self, selection, task, question, max_events, scene_state=None):
+        return (
+            build_video_reasoning_prompt(
+                selection,
+                task=task,
+                question=question,
+                max_events=max_events,
+                scene_state=scene_state,
+            ),
+            json.dumps(VIDEO_REASONING_JSON_SCHEMA, indent=2, sort_keys=True),
+        )
+
+
+class VLMEventsFromVideoJSON:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "text": ("STRING", {"multiline": True}),
+                "selection": (VLM_VIDEO_SELECTION,),
+                "max_events": (
+                    "INT",
+                    {"default": 256, "min": 1, "max": 4096},
+                ),
+            }
+        }
+
+    RETURN_TYPES = (VLM_EVENTS, "STRING", "STRING")
+    RETURN_NAMES = ("events", "summary", "normalized_json")
+    FUNCTION = "parse"
+    CATEGORY = "VLM Nodes/Video Intelligence"
+
+    def parse(self, text, selection, max_events):
+        summary, events, normalized = parse_video_reasoning_output(
+            text,
+            selection,
+            max_events=max_events,
+        )
+        return events, summary, normalized
+
+
+class VLMVideoTemporalReasoner(ModernVLM):
+    """Convenience node: adaptively sample, reason, and validate in one call."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "frames": ("IMAGE",),
+                "fps": (
+                    "FLOAT",
+                    {"default": 24.0, "min": 0.01, "max": 1000.0, "step": 0.01},
+                ),
+                "task": (VIDEO_TASKS, {"default": "Action timeline"}),
+                "question": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "What changes over time?",
+                    },
+                ),
+                "model": (
+                    list(RECOMMENDED_MODEL_LABELS),
+                    {"default": "SmolVLM2 2.2B Video"},
+                ),
+                "custom_model_id": ("STRING", {"default": ""}),
+                "memory_mode": (
+                    MEMORY_MODES,
+                    {"default": "ComfyUI managed (BF16)"},
+                ),
+                "max_frames": (
+                    "INT",
+                    {"default": 16, "min": 1, "max": 512},
+                ),
+                "max_events": (
+                    "INT",
+                    {"default": 24, "min": 1, "max": 256},
+                ),
+                "max_new_tokens": (
+                    "INT",
+                    {"default": 768, "min": 32, "max": 16384},
+                ),
+            },
+            "optional": {
+                "tracks": (VLM_TRACKS,),
+                "scene_state": (VLM_SCENE_STATE,),
+                "strategy": (
+                    SAMPLING_STRATEGIES,
+                    {"default": "Hybrid: scene + motion + tracks"},
+                ),
+                "minimum_gap_seconds": (
+                    "FLOAT",
+                    {"default": 0.15, "min": 0.0, "max": 60.0, "step": 0.01},
+                ),
+                "analysis_max_side": (
+                    "INT",
+                    {
+                        "default": 448,
+                        "min": 0,
+                        "max": 4096,
+                        "step": 64,
+                        "tooltip": (
+                            "Downscale sampled frames before the VLM. 0 keeps "
+                            "the source resolution; 448 is the fast default."
+                        ),
+                    },
+                ),
+                "attention_mode": (
+                    ATTENTION_MODES,
+                    {"default": "Auto (SDPA)"},
+                ),
+                "enable_thinking": ("BOOLEAN", {"default": False}),
+                "strict_output": ("BOOLEAN", {"default": True}),
+                "unload_after": ("BOOLEAN", {"default": False}),
+                "stream_output": ("BOOLEAN", {"default": True}),
+            },
+            "hidden": {"unique_id": "UNIQUE_ID"},
+        }
+
+    RETURN_TYPES = (
+        "STRING",
+        VLM_EVENTS,
+        VLM_VIDEO_SELECTION,
+        "IMAGE",
+        "STRING",
+        "STRING",
+        "STRING",
+        "STRING",
+    )
+    RETURN_NAMES = (
+        "summary",
+        "events",
+        "selection",
+        "sampled_frames",
+        "raw_response",
+        "diagnostics_json",
+        "events_json",
+        "selection_json",
+    )
+    FUNCTION = "analyze"
+    CATEGORY = "VLM Nodes/Video Intelligence"
+
+    def analyze(
+        self,
+        frames,
+        fps,
+        task,
+        question,
+        model,
+        custom_model_id,
+        memory_mode,
+        max_frames,
+        max_events,
+        max_new_tokens,
+        tracks=None,
+        scene_state=None,
+        strategy="Hybrid: scene + motion + tracks",
+        minimum_gap_seconds=0.15,
+        analysis_max_side=448,
+        attention_mode="Auto (SDPA)",
+        enable_thinking=False,
+        strict_output=True,
+        unload_after=False,
+        stream_output=True,
+        unique_id=None,
+    ):
+        sampled, selection, diagnostics = sample_video_frames(
+            frames,
+            fps=fps,
+            max_frames=max_frames,
+            strategy=strategy,
+            minimum_gap_seconds=minimum_gap_seconds,
+            tracks=tracks,
+        )
+        prompt = build_video_reasoning_prompt(
+            selection,
+            task=task,
+            question=question,
+            max_events=max_events,
+            scene_state=scene_state,
+        )
+        analysis_frames = resize_video_for_analysis(
+            sampled,
+            max_side=analysis_max_side,
+        )
+        diagnostics["source_resolution"] = [
+            int(sampled.shape[2]),
+            int(sampled.shape[1]),
+        ]
+        diagnostics["analysis_resolution"] = [
+            int(analysis_frames.shape[2]),
+            int(analysis_frames.shape[1]),
+        ]
+        diagnostics["analysis_pixel_reduction_ratio"] = 1.0 - (
+            analysis_frames.shape[1] * analysis_frames.shape[2]
+        ) / (sampled.shape[1] * sampled.shape[2])
+        reasoning_started = time.perf_counter()
+        raw_response = super().run(
+            prompt=prompt,
+            model=model,
+            custom_model_id=custom_model_id,
+            memory_mode=memory_mode,
+            max_new_tokens=max_new_tokens,
+            temperature=0.0,
+            top_p=1.0,
+            image=None,
+            system_prompt=(
+                "You are a precise temporal video analyst. Use only visible "
+                "evidence, preserve source timestamps, and obey the JSON Schema."
+            ),
+            video_frames=analysis_frames,
+            fps=fps,
+            video_selection=selection,
+            attention_mode=attention_mode,
+            enable_thinking=enable_thinking,
+            unload_after=unload_after,
+            stream_output=stream_output,
+            unique_id=unique_id,
+        )[0]
+        diagnostics["reasoning_ms"] = (
+            time.perf_counter() - reasoning_started
+        ) * 1000
+        try:
+            summary, events, _normalized = parse_video_reasoning_output(
+                raw_response,
+                selection,
+                max_events=max_events,
+            )
+            diagnostics["structured_output_valid"] = True
+        except (TypeError, ValueError) as exc:
+            diagnostics["structured_output_valid"] = False
+            diagnostics["structured_output_error"] = str(exc)
+            if strict_output:
+                raise ValueError(
+                    "The video VLM did not return valid structured temporal "
+                    f"output: {exc}"
+                ) from exc
+            summary = raw_response.strip()
+            events = EventSequence(
+                duration=selection.duration,
+                source="video-vlm-unstructured",
+                metadata={"validation_failed": True},
+            )
+        return (
+            summary,
+            events,
+            selection,
+            sampled,
+            raw_response,
+            json.dumps(diagnostics, indent=2, sort_keys=True),
+            events.to_json(indent=2),
+            selection.to_json(indent=2),
+        )
+
+
+NODE_CLASS_MAPPINGS = {
+    "VLMAdaptiveFrameSampler": VLMAdaptiveFrameSampler,
+    "VLMTrackAwareCrops": VLMTrackAwareCrops,
+    "VLMBuildSceneState": VLMBuildSceneState,
+    "VLMVideoReasoningPrompt": VLMVideoReasoningPrompt,
+    "VLMEventsFromVideoJSON": VLMEventsFromVideoJSON,
+    "VLMVideoTemporalReasoner": VLMVideoTemporalReasoner,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "VLMAdaptiveFrameSampler": "VLM Adaptive Frame Sampler",
+    "VLMTrackAwareCrops": "VLM Track-Aware Semantic Crops",
+    "VLMBuildSceneState": "VLM Persistent Scene State",
+    "VLMVideoReasoningPrompt": "VLM Video Reasoning Prompt",
+    "VLMEventsFromVideoJSON": "VLM Temporal Events From JSON",
+    "VLMVideoTemporalReasoner": "VLM Video Temporal Reasoner",
+}
+
+__all__ = [
+    "NODE_CLASS_MAPPINGS",
+    "NODE_DISPLAY_NAME_MAPPINGS",
+    "SAMPLING_STRATEGIES",
+    "VIDEO_REASONING_JSON_SCHEMA",
+    "VIDEO_TASKS",
+    "build_scene_state",
+    "build_video_reasoning_prompt",
+    "parse_video_reasoning_output",
+    "resize_video_for_analysis",
+    "sample_video_frames",
+    "scene_state_summary",
+    "track_aware_crops",
+]

--- a/nodes/vision_types.py
+++ b/nodes/vision_types.py
@@ -19,12 +19,16 @@ VLM_DETECTIONS = "VLM_DETECTIONS"
 VLM_TRACKS = "VLM_TRACKS"
 VLM_POINTS = "VLM_POINTS"
 VLM_EVENTS = "VLM_EVENTS"
+VLM_VIDEO_SELECTION = "VLM_VIDEO_SELECTION"
+VLM_SCENE_STATE = "VLM_SCENE_STATE"
 
 SCHEMA_VERSION = 1
 DETECTIONS_SCHEMA = "comfyui-vlm/detections"
 TRACKS_SCHEMA = "comfyui-vlm/tracks"
 POINTS_SCHEMA = "comfyui-vlm/points"
 EVENTS_SCHEMA = "comfyui-vlm/events"
+VIDEO_SELECTION_SCHEMA = "comfyui-vlm/video-selection"
+SCENE_STATE_SCHEMA = "comfyui-vlm/scene-state"
 
 PointXY = tuple[float, float]
 BoxXYXY = tuple[float, float, float, float]
@@ -972,6 +976,403 @@ class EventSequence:
             raise ValueError(f"Invalid event JSON: {exc.msg}.") from exc
 
 
+@dataclass(frozen=True, slots=True)
+class SelectedVideoFrame:
+    """One source-frame reference preserved through adaptive sampling."""
+
+    source_frame_index: int
+    timestamp: float
+    score: float = 0.0
+    reasons: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.source_frame_index, int)
+            or self.source_frame_index < 0
+        ):
+            raise ValueError("source_frame_index must be a non-negative integer.")
+        object.__setattr__(
+            self,
+            "timestamp",
+            _non_negative(self.timestamp, "timestamp"),
+        )
+        score = _finite(self.score, "selection score")
+        if not 0.0 <= score <= 1.0:
+            raise ValueError("selection score must be between 0 and 1.")
+        object.__setattr__(self, "score", score)
+        reasons = tuple(self.reasons)
+        if any(not isinstance(reason, str) or not reason.strip() for reason in reasons):
+            raise TypeError("selection reasons must be non-empty strings.")
+        object.__setattr__(self, "reasons", reasons)
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "source_frame_index": self.source_frame_index,
+            "timestamp": self.timestamp,
+            "score": self.score,
+        }
+        if self.reasons:
+            result["reasons"] = list(self.reasons)
+        return result
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> SelectedVideoFrame:
+        if not isinstance(value, Mapping):
+            raise TypeError("A selected video frame must be a JSON object.")
+        return cls(
+            source_frame_index=value["source_frame_index"],
+            timestamp=value["timestamp"],
+            score=value.get("score", 0.0),
+            reasons=tuple(value.get("reasons", ())),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class VideoFrameSelection:
+    """Immutable map from a sampled IMAGE batch back to its source video."""
+
+    width: int
+    height: int
+    source_frame_count: int
+    fps: float
+    frames: tuple[SelectedVideoFrame, ...]
+    strategy: str = "adaptive"
+    source: str | None = None
+    metadata: FrozenDict = field(default_factory=FrozenDict)
+    version: int = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.version != SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported video selection schema version {self.version}."
+            )
+        if not isinstance(self.width, int) or self.width <= 0:
+            raise ValueError("width must be a positive integer.")
+        if not isinstance(self.height, int) or self.height <= 0:
+            raise ValueError("height must be a positive integer.")
+        if (
+            not isinstance(self.source_frame_count, int)
+            or self.source_frame_count <= 0
+        ):
+            raise ValueError("source_frame_count must be a positive integer.")
+        fps = _finite(self.fps, "fps")
+        if fps <= 0:
+            raise ValueError("fps must be positive.")
+        frames = tuple(self.frames)
+        if not frames:
+            raise ValueError("A video selection requires at least one frame.")
+        if any(not isinstance(frame, SelectedVideoFrame) for frame in frames):
+            raise TypeError("frames must contain SelectedVideoFrame values.")
+        indices = [frame.source_frame_index for frame in frames]
+        if indices != sorted(set(indices)):
+            raise ValueError(
+                "Selected source frame indices must be unique and increasing."
+            )
+        if indices[-1] >= self.source_frame_count:
+            raise ValueError("A selected frame lies outside the source video.")
+        expected_timestamps = [index / fps for index in indices]
+        if any(
+            abs(frame.timestamp - expected) > max(1.0e-6, 0.51 / fps)
+            for frame, expected in zip(frames, expected_timestamps)
+        ):
+            raise ValueError(
+                "Selected frame timestamps do not match source indices and fps."
+            )
+        strategy = str(self.strategy).strip()
+        if not strategy:
+            raise ValueError("strategy must not be empty.")
+        object.__setattr__(self, "fps", fps)
+        object.__setattr__(self, "frames", frames)
+        object.__setattr__(self, "strategy", strategy)
+        object.__setattr__(self, "source", _optional_text(self.source, "source"))
+        object.__setattr__(self, "metadata", _metadata(self.metadata))
+
+    @property
+    def duration(self) -> float:
+        return self.source_frame_count / self.fps
+
+    @property
+    def indices(self) -> tuple[int, ...]:
+        return tuple(frame.source_frame_index for frame in self.frames)
+
+    @property
+    def timestamps(self) -> tuple[float, ...]:
+        return tuple(frame.timestamp for frame in self.frames)
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "schema": VIDEO_SELECTION_SCHEMA,
+            "version": self.version,
+            "media": {
+                "width": self.width,
+                "height": self.height,
+                "source_frame_count": self.source_frame_count,
+                "fps": self.fps,
+                "duration": self.duration,
+            },
+            "strategy": self.strategy,
+            "frames": [frame.to_dict() for frame in self.frames],
+        }
+        if self.source is not None:
+            result["source"] = self.source
+        if self.metadata:
+            result["metadata"] = self.metadata.to_dict()
+        return result
+
+    def to_json(self, *, indent: int | None = None) -> str:
+        return json.dumps(
+            self.to_dict(),
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            indent=indent,
+        )
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> VideoFrameSelection:
+        if not isinstance(value, Mapping):
+            raise TypeError("Video selection JSON must contain an object.")
+        if value.get("schema") != VIDEO_SELECTION_SCHEMA:
+            raise ValueError(f"Expected schema {VIDEO_SELECTION_SCHEMA!r}.")
+        if value.get("version") != SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported video selection schema version "
+                f"{value.get('version')!r}."
+            )
+        media = value.get("media")
+        if not isinstance(media, Mapping):
+            raise ValueError("Video selection JSON requires a media object.")
+        return cls(
+            width=media["width"],
+            height=media["height"],
+            source_frame_count=media["source_frame_count"],
+            fps=media["fps"],
+            frames=tuple(
+                SelectedVideoFrame.from_dict(frame)
+                for frame in value.get("frames", ())
+            ),
+            strategy=value.get("strategy", "adaptive"),
+            source=value.get("source"),
+            metadata=value.get("metadata"),
+            version=value["version"],
+        )
+
+    @classmethod
+    def from_json(cls, value: str) -> VideoFrameSelection:
+        try:
+            return cls.from_dict(json.loads(value))
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid video selection JSON: {exc.msg}.") from exc
+
+
+@dataclass(frozen=True, slots=True)
+class SceneObjectState:
+    """Compact latest state derived from a temporally consistent object track."""
+
+    track_id: int
+    first_seen: float
+    last_seen: float
+    last_bbox_xyxy: BoxXYXY
+    observation_count: int
+    label: str | None = None
+    state: str = "active"
+    mean_confidence: float | None = None
+    velocity_xy_px_s: PointXY = (0.0, 0.0)
+    metadata: FrozenDict = field(default_factory=FrozenDict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.track_id, int) or self.track_id < 0:
+            raise ValueError("track_id must be a non-negative integer.")
+        first_seen = _non_negative(self.first_seen, "first_seen")
+        last_seen = _non_negative(self.last_seen, "last_seen")
+        if last_seen < first_seen:
+            raise ValueError("last_seen must be at or after first_seen.")
+        if (
+            not isinstance(self.observation_count, int)
+            or self.observation_count <= 0
+        ):
+            raise ValueError("observation_count must be a positive integer.")
+        state = str(self.state).strip()
+        if not state:
+            raise ValueError("state must not be empty.")
+        velocity = tuple(_finite(value, "velocity") for value in self.velocity_xy_px_s)
+        if len(velocity) != 2:
+            raise ValueError("velocity_xy_px_s must contain exactly two values.")
+        object.__setattr__(self, "first_seen", first_seen)
+        object.__setattr__(self, "last_seen", last_seen)
+        object.__setattr__(self, "last_bbox_xyxy", _box(self.last_bbox_xyxy))
+        object.__setattr__(self, "label", _optional_text(self.label, "label"))
+        object.__setattr__(self, "state", state)
+        object.__setattr__(
+            self,
+            "mean_confidence",
+            _optional_score(self.mean_confidence),
+        )
+        object.__setattr__(self, "velocity_xy_px_s", velocity)
+        object.__setattr__(self, "metadata", _metadata(self.metadata))
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "track_id": self.track_id,
+            "first_seen": self.first_seen,
+            "last_seen": self.last_seen,
+            "last_bbox_xyxy": list(self.last_bbox_xyxy),
+            "observation_count": self.observation_count,
+            "state": self.state,
+            "velocity_xy_px_s": list(self.velocity_xy_px_s),
+        }
+        if self.label is not None:
+            result["label"] = self.label
+        if self.mean_confidence is not None:
+            result["mean_confidence"] = self.mean_confidence
+        if self.metadata:
+            result["metadata"] = self.metadata.to_dict()
+        return result
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> SceneObjectState:
+        if not isinstance(value, Mapping):
+            raise TypeError("A scene object must be a JSON object.")
+        return cls(
+            track_id=value["track_id"],
+            first_seen=value["first_seen"],
+            last_seen=value["last_seen"],
+            last_bbox_xyxy=value["last_bbox_xyxy"],
+            observation_count=value["observation_count"],
+            label=value.get("label"),
+            state=value.get("state", "active"),
+            mean_confidence=value.get("mean_confidence"),
+            velocity_xy_px_s=tuple(value.get("velocity_xy_px_s", (0.0, 0.0))),
+            metadata=value.get("metadata"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SceneState:
+    """Persistent, serializable world-state summary for video reasoning."""
+
+    width: int
+    height: int
+    frame_count: int
+    fps: float | None
+    objects: tuple[SceneObjectState, ...] = ()
+    events: tuple[TemporalEvent, ...] = ()
+    source: str | None = None
+    metadata: FrozenDict = field(default_factory=FrozenDict)
+    version: int = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.version != SCHEMA_VERSION:
+            raise ValueError(f"Unsupported scene state schema version {self.version}.")
+        if not isinstance(self.width, int) or self.width <= 0:
+            raise ValueError("width must be a positive integer.")
+        if not isinstance(self.height, int) or self.height <= 0:
+            raise ValueError("height must be a positive integer.")
+        if not isinstance(self.frame_count, int) or self.frame_count < 0:
+            raise ValueError("frame_count must be a non-negative integer.")
+        fps = None if self.fps is None else _finite(self.fps, "fps")
+        if fps is not None and fps <= 0:
+            raise ValueError("fps must be positive.")
+        objects = tuple(self.objects)
+        if any(not isinstance(item, SceneObjectState) for item in objects):
+            raise TypeError("objects must contain SceneObjectState values.")
+        ids = [item.track_id for item in objects]
+        if ids != sorted(set(ids)):
+            raise ValueError("Scene objects must have unique increasing track IDs.")
+        events = tuple(self.events)
+        if any(not isinstance(item, TemporalEvent) for item in events):
+            raise TypeError("events must contain TemporalEvent values.")
+        if list(events) != sorted(
+            events,
+            key=lambda event: (event.start_time, event.end_time),
+        ):
+            raise ValueError("Scene events must be ordered by start_time.")
+        object.__setattr__(self, "fps", fps)
+        object.__setattr__(self, "objects", objects)
+        object.__setattr__(self, "events", events)
+        object.__setattr__(self, "source", _optional_text(self.source, "source"))
+        object.__setattr__(self, "metadata", _metadata(self.metadata))
+
+    @property
+    def duration(self) -> float | None:
+        return (
+            self.frame_count / self.fps
+            if self.fps is not None and self.frame_count
+            else None
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        media: dict[str, Any] = {
+            "width": self.width,
+            "height": self.height,
+            "frame_count": self.frame_count,
+        }
+        if self.fps is not None:
+            media["fps"] = self.fps
+        if self.duration is not None:
+            media["duration"] = self.duration
+        result: dict[str, Any] = {
+            "schema": SCENE_STATE_SCHEMA,
+            "version": self.version,
+            "media": media,
+            "objects": [item.to_dict() for item in self.objects],
+            "events": [item.to_dict() for item in self.events],
+        }
+        if self.source is not None:
+            result["source"] = self.source
+        if self.metadata:
+            result["metadata"] = self.metadata.to_dict()
+        return result
+
+    def to_json(self, *, indent: int | None = None) -> str:
+        return json.dumps(
+            self.to_dict(),
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            indent=indent,
+        )
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> SceneState:
+        if not isinstance(value, Mapping):
+            raise TypeError("Scene state JSON must contain an object.")
+        if value.get("schema") != SCENE_STATE_SCHEMA:
+            raise ValueError(f"Expected schema {SCENE_STATE_SCHEMA!r}.")
+        if value.get("version") != SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported scene state schema version "
+                f"{value.get('version')!r}."
+            )
+        media = value.get("media")
+        if not isinstance(media, Mapping):
+            raise ValueError("Scene state JSON requires a media object.")
+        return cls(
+            width=media["width"],
+            height=media["height"],
+            frame_count=media["frame_count"],
+            fps=media.get("fps"),
+            objects=tuple(
+                SceneObjectState.from_dict(item)
+                for item in value.get("objects", ())
+            ),
+            events=tuple(
+                TemporalEvent.from_dict(item)
+                for item in value.get("events", ())
+            ),
+            source=value.get("source"),
+            metadata=value.get("metadata"),
+            version=value["version"],
+        )
+
+    @classmethod
+    def from_json(cls, value: str) -> SceneState:
+        try:
+            return cls.from_dict(json.loads(value))
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid scene state JSON: {exc.msg}.") from exc
+
+
 __all__ = [
     "BoxXYXY",
     "DETECTIONS_SCHEMA",
@@ -985,7 +1386,11 @@ __all__ = [
     "PointSequence",
     "PointXY",
     "Polygon",
+    "SCENE_STATE_SCHEMA",
     "SCHEMA_VERSION",
+    "SceneObjectState",
+    "SceneState",
+    "SelectedVideoFrame",
     "TRACKS_SCHEMA",
     "TemporalEvent",
     "Track",
@@ -993,6 +1398,10 @@ __all__ = [
     "VLM_DETECTIONS",
     "VLM_EVENTS",
     "VLM_POINTS",
+    "VLM_SCENE_STATE",
     "VLM_TRACKS",
+    "VLM_VIDEO_SELECTION",
+    "VIDEO_SELECTION_SCHEMA",
+    "VideoFrameSelection",
     "VisionPoint",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "comfyui_vlm_nodes"
-version = "3.1.0"
+version = "3.2.0"
 description = "Production-ready local and API vision-language nodes for ComfyUI"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -58,6 +58,8 @@ Icon = ""
 [tool.setuptools]
 packages = [
   "comfyui_vlm_nodes",
+  "comfyui_vlm_nodes.examples",
+  "comfyui_vlm_nodes.examples.vision",
   "comfyui_vlm_nodes.nodes",
   "comfyui_vlm_nodes.nodes.joytagger",
   "comfyui_vlm_nodes.web",
@@ -72,6 +74,8 @@ comfyui_vlm_nodes = "."
 comfyui_vlm_nodes = [
   "*.json",
   "SECURITY.md",
+  "examples/*.json",
+  "examples/vision/*.json",
   "requirements*.txt",
 ]
 "comfyui_vlm_nodes.web.js" = ["*.js"]

--- a/tests/manual_video_intelligence_smoke.py
+++ b/tests/manual_video_intelligence_smoke.py
@@ -1,0 +1,176 @@
+"""Run adaptive temporal reasoning on a real local video and real VLM.
+
+Example:
+    python tests/manual_video_intelligence_smoke.py \
+        /mnt/d/002.mp4 \
+        --model "Qwen 3 VL 2B Instruct" \
+        --output /mnt/d/comfyui-repair/video-intelligence-audit/result.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+import time
+from pathlib import Path
+
+import av
+import torch
+
+REPOSITORY = Path(__file__).resolve().parents[1]
+if REPOSITORY.name != "ComfyUI_VLM_nodes":
+    specification = importlib.util.spec_from_file_location(
+        "ComfyUI_VLM_nodes",
+        REPOSITORY / "__init__.py",
+        submodule_search_locations=[str(REPOSITORY)],
+    )
+    if specification is None or specification.loader is None:
+        raise RuntimeError(f"Could not load package from {REPOSITORY}.")
+    package = importlib.util.module_from_spec(specification)
+    sys.modules["ComfyUI_VLM_nodes"] = package
+    specification.loader.exec_module(package)
+
+from ComfyUI_VLM_nodes.nodes.modern_vlm import ModernVLMPredictor
+from ComfyUI_VLM_nodes.nodes.video_intelligence import (
+    build_video_reasoning_prompt,
+    parse_video_reasoning_output,
+    resize_video_for_analysis,
+    sample_video_frames,
+)
+
+
+def load_video(path: Path) -> tuple[torch.Tensor, float]:
+    container = av.open(str(path))
+    try:
+        stream = container.streams.video[0]
+        rate = stream.average_rate or stream.guessed_rate
+        if rate is None:
+            raise RuntimeError("The video does not report a frame rate.")
+        frames = [
+            torch.from_numpy(frame.to_ndarray(format="rgb24")).to(torch.float32)
+            / 255.0
+            for frame in container.decode(stream)
+        ]
+    finally:
+        container.close()
+    if not frames:
+        raise RuntimeError("The video contains no decodable frames.")
+    return torch.stack(frames), float(rate)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("video", type=Path)
+    parser.add_argument(
+        "--model",
+        default="Qwen 3 VL 2B Instruct",
+    )
+    parser.add_argument("--max-frames", type=int, default=12)
+    parser.add_argument("--analysis-max-side", type=int, default=448)
+    parser.add_argument("--max-new-tokens", type=int, default=512)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    frames, fps = load_video(args.video)
+    sampled, selection, diagnostics = sample_video_frames(
+        frames,
+        fps=fps,
+        max_frames=args.max_frames,
+        strategy="Hybrid: scene + motion + tracks",
+        minimum_gap_seconds=0.2,
+    )
+    prompt = build_video_reasoning_prompt(
+        selection,
+        task="Detailed temporal summary",
+        question="What happens, and how do the people behave over time?",
+        max_events=12,
+    )
+    analysis_frames = resize_video_for_analysis(
+        sampled,
+        max_side=args.analysis_max_side,
+    )
+    predictor = ModernVLMPredictor(
+        args.model,
+        "",
+        "ComfyUI managed (BF16)",
+        "Auto (SDPA)",
+    )
+    started = time.perf_counter()
+    try:
+        raw = predictor.generate(
+            images=None,
+            prompt=prompt,
+            system_prompt=(
+                "You are a precise temporal video analyst. Return one JSON "
+                "object that obeys the supplied schema."
+            ),
+            max_new_tokens=args.max_new_tokens,
+            temperature=0.0,
+            top_p=1.0,
+            video_frames=analysis_frames,
+            fps=fps,
+            video_selection=selection,
+        )
+    finally:
+        predictor.close()
+    reasoning_seconds = time.perf_counter() - started
+    result = {
+        "video": str(args.video),
+        "model": args.model,
+        "source_shape": list(frames.shape),
+        "fps": fps,
+        "selection": selection.to_dict(),
+        "sampling": diagnostics,
+        "analysis_shape": list(analysis_frames.shape),
+        "reasoning_seconds": reasoning_seconds,
+        "raw_response": raw,
+        "cuda_peak_gib": (
+            torch.cuda.max_memory_allocated() / 2**30
+            if torch.cuda.is_available()
+            else 0.0
+        ),
+    }
+    try:
+        summary, events, normalized = parse_video_reasoning_output(raw, selection)
+    except (TypeError, ValueError) as exc:
+        result["structured_output_valid"] = False
+        result["structured_output_error"] = str(exc)
+        if args.output:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(
+                json.dumps(
+                    result,
+                    ensure_ascii=False,
+                    allow_nan=False,
+                    indent=2,
+                    sort_keys=True,
+                ),
+                encoding="utf-8",
+            )
+        raise
+    result.update(
+        {
+            "structured_output_valid": True,
+            "summary": summary,
+            "events": events.to_dict(),
+            "normalized_response": json.loads(normalized),
+        }
+    )
+    encoded = json.dumps(
+        result,
+        ensure_ascii=False,
+        allow_nan=False,
+        indent=2,
+        sort_keys=True,
+    )
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(encoded, encoding="utf-8")
+    print(encoded)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -40,6 +40,7 @@ def test_every_module_imports_and_expected_nodes_exist():
     assert package.IMPORT_ERRORS == {}
     expected = {
         "ModernVLM",
+        "LegacyModernVLM",
         "VLMRuntimeDiagnostics",
         "Florence2",
         "Paligemma",
@@ -410,6 +411,37 @@ def test_modern_catalog_has_current_quality_and_low_vram_tiers():
     assert "ibm-granite/granite-vision-4.1-4b" in repositories
 
 
+def test_modern_picker_is_curated_and_legacy_models_remain_compatible():
+    visible = tuple(modern_vlm.ModernVLM.INPUT_TYPES()["required"]["model"][0])
+    legacy = tuple(
+        modern_vlm.LegacyModernVLM.INPUT_TYPES()["required"]["model"][0]
+    )
+    assert visible == modern_vlm.RECOMMENDED_MODEL_LABELS
+    assert legacy == modern_vlm.LEGACY_MODEL_LABELS
+    assert len(visible) == 12
+    assert set(visible).isdisjoint(legacy)
+    assert set(visible) | set(legacy) == set(modern_vlm.MODEL_CATALOG)
+    assert (
+        modern_vlm.ModernVLM.VALIDATE_INPUTS(
+            "Qwen 2.5 VL 3B Instruct (legacy workflows)"
+        )
+        is True
+    )
+    for node_name in (
+        "Kosmos2model",
+        "MCLLaVAModel",
+        "MiniCPMNode",
+        "MolmoNode",
+        "MoonDream",
+        "Paligemma",
+        "Qwen2VLNode",
+        "UformGen2QwenNode",
+    ):
+        assert package.NODE_CLASS_MAPPINGS[node_name].CATEGORY.startswith(
+            "VLM Nodes/Legacy/"
+        )
+
+
 def test_modern_video_is_primary_input_and_thinking_is_explicit():
     assert "image" in modern_vlm.ModernVLM.INPUT_TYPES()["optional"]
     assert "image" in qwen2vl.Qwen2VLNode.INPUT_TYPES()["optional"]
@@ -513,6 +545,11 @@ def test_view_text_frontend_rehydrates_and_uses_native_progress_channel():
     assert 'api.addEventListener("progress_text"' in source
     assert "onNodeOutputsUpdated(nodeOutputs)" in source
     assert "connectedViewTextNodes(source)" in source
+    assert '"VLMVideoTemporalReasoner"' in source
+    assert 'makeButton("Save"' in source
+    assert 'makeButton("Wrap: on"' in source
+    assert 'makeButton("Follow: on"' in source
+    assert "isReroute(target)" in source
 
 
 def test_internvl_video_uses_an_even_vision_patch_grid():

--- a/tests/test_simpletext.py
+++ b/tests/test_simpletext.py
@@ -1,0 +1,212 @@
+import json
+from pathlib import Path
+
+import pytest
+
+import ComfyUI_VLM_nodes as package
+from ComfyUI_VLM_nodes.nodes import simpletext
+
+
+def test_simple_text_preserves_legacy_default_and_appends_metrics():
+    result = simpletext.SimpleText().simple_text("  one\r\ntwo  ")
+    assert result == ("  one\r\ntwo  ", 12, 2, 2)
+
+    normalized = simpletext.SimpleText().simple_text(
+        "  one\r\ntwo  ",
+        trim_edges=True,
+        normalize_newlines=True,
+    )
+    assert normalized == ("one\ntwo", 7, 2, 2)
+
+
+def test_json_to_text_keeps_legacy_smart_rendering_and_adds_canonical_output():
+    response = simpletext.JsonToText().json_to_text(
+        '{"prompt":"Create a red kite","suggestion1":"at sunset","tags":["red","sky"]}'
+    )
+    assert response["result"][0] == "a red kite\n\nat sunset\n\ntags: red, sky"
+    assert json.loads(response["result"][1])["tags"] == ["red", "sky"]
+    assert response["result"][2] == 3
+
+
+def test_json_to_text_parses_fenced_model_response_and_json_paths():
+    response = simpletext.JsonToText().json_to_text(
+        'Model response:\n```json\n{"result":{"items":[{"name":"café"}]}}\n```',
+        format_mode="Pretty JSON",
+        json_path="$.result.items[0]",
+    )
+    assert json.loads(response["result"][0]) == {"name": "café"}
+    assert response["result"][1] == '{"name":"café"}'
+
+    pointer = simpletext.VLMJSONExtract().extract(
+        '{"a/b":{"~key":[10,20]}}',
+        "/a~1b/~0key/1",
+        "Text",
+        "Error",
+        "",
+    )
+    assert pointer == ("20", True, "integer", "20")
+
+
+def test_json_extract_handles_negative_indexes_and_missing_policy():
+    node = simpletext.VLMJSONExtract()
+    assert node.extract(
+        '{"items":["first","last"]}',
+        "$.items[-1]",
+        "Text",
+        "Error",
+        "",
+    )[:3] == ("last", True, "string")
+    assert node.extract(
+        '{"items":[]}',
+        "$.missing",
+        "Text",
+        "Default value",
+        "fallback",
+    )[:3] == ("fallback", False, "string")
+    with pytest.raises(ValueError, match="not found"):
+        node.extract("{}", "$.missing", "Text", "Error", "")
+
+
+def test_text_join_drops_empty_and_duplicate_parts():
+    result = simpletext.VLMTextJoin().join(
+        " first ",
+        "Blank line",
+        "|",
+        True,
+        True,
+        True,
+        text_b="second",
+        text_c="first",
+    )
+    assert result == (
+        "first\n\nsecond",
+        '["first","second"]',
+        2,
+    )
+
+
+def test_text_template_is_safe_explicit_and_supports_literal_braces():
+    result = simpletext.VLMTextTemplate().render(
+        "{{schema}} {subject}: {text1}",
+        '{"subject":"robot"}',
+        "Error",
+        text1="moving a box",
+    )
+    assert result[0] == "{schema} robot: moving a box"
+    assert json.loads(result[1]) == {
+        "subject": "robot",
+        "text1": "moving a box",
+    }
+    assert result[2] == "[]"
+
+    with pytest.raises(ValueError, match="missing"):
+        simpletext.VLMTextTemplate().render(
+            "{known} {unknown}",
+            '{"known":"yes"}',
+            "Error",
+        )
+
+
+def test_text_clean_normalizes_fences_duplicates_and_length():
+    result, diagnostics_json = simpletext.VLMTextClean().clean(
+        "```text\r\nＡ  B\r\nＡ  B\r\nC\r\n```",
+        "NFKC",
+        "Collapse horizontal",
+        True,
+        True,
+        True,
+        5,
+    )
+    assert result == "A B\nC"
+    diagnostics = json.loads(diagnostics_json)
+    assert diagnostics["changed"] is True
+    assert diagnostics["duplicate_lines_removed"] == 1
+    assert diagnostics["truncated"] is False
+
+
+def test_text_replace_literal_regex_and_errors():
+    node = simpletext.VLMTextReplace()
+    assert node.replace(
+        "Cat cat cat",
+        "cat",
+        "dog",
+        "Literal",
+        False,
+        2,
+        "Keep text",
+    )[:2] == ("dog dog cat", 2)
+    assert node.replace(
+        "a1 b22",
+        r"\d+",
+        "#",
+        "Regular expression",
+        True,
+        0,
+        "Keep text",
+    )[:2] == ("a# b#", 2)
+    with pytest.raises(ValueError, match="not found"):
+        node.replace("hello", "x", "y", "Literal", True, 0, "Error")
+
+
+def test_text_split_outputs_real_list_and_stable_json():
+    items, items_json, count = simpletext.VLMTextSplit().split(
+        '[" first ","second","first",""]',
+        "JSON array",
+        ",",
+        True,
+        True,
+        True,
+        0,
+    )
+    assert items == ["first", "second"]
+    assert json.loads(items_json) == items
+    assert count == 2
+    assert simpletext.VLMTextSplit.OUTPUT_IS_LIST == (True, False, False)
+
+
+def test_text_inspector_and_view_text_report_same_metrics():
+    inspected = simpletext.VLMTextInspect().inspect("hello\nworld")
+    assert inspected[1:6] == (11, 11, 2, 2, 3)
+    assert len(inspected[6]) == 64
+    assert json.loads(inspected[7])["words"] == 2
+
+    viewed = simpletext.ViewText().view_text("hello\nworld")
+    assert viewed["result"][:4] == ("hello\nworld", 11, 2, 2)
+    assert viewed["ui"]["text"] == ["hello\nworld"]
+
+
+def test_text_node_categories_aliases_and_legacy_ids_are_stable():
+    assert simpletext.NODE_CLASS_MAPPINGS["SimpleText"] is simpletext.SimpleText
+    assert simpletext.NODE_CLASS_MAPPINGS["JsonToText"] is simpletext.JsonToText
+    assert simpletext.NODE_CLASS_MAPPINGS["ViewText"] is simpletext.ViewText
+    assert set(simpletext.NODE_CLASS_MAPPINGS) == {
+        "SimpleText",
+        "JsonToText",
+        "ViewText",
+        "VLMTextJoin",
+        "VLMTextTemplate",
+        "VLMTextClean",
+        "VLMTextReplace",
+        "VLMJSONExtract",
+        "VLMTextSplit",
+        "VLMTextInspect",
+    }
+    assert simpletext.SimpleText.CATEGORY == "VLM Nodes/Text/Create"
+    assert simpletext.ViewText.CATEGORY == "VLM Nodes/Text/Inspect"
+
+
+def test_text_toolkit_api_example_uses_registered_inputs_and_output_indexes():
+    root = Path(package.__file__).parent
+    prompt = json.loads(
+        (root / "examples" / "text_toolkit_api.json").read_text("utf-8")
+    )
+    assert prompt["5"]["inputs"]["text"] == ["4", 0]
+    for node in prompt.values():
+        node_class = package.NODE_CLASS_MAPPINGS[node["class_type"]]
+        declared = {
+            name
+            for group in node_class.INPUT_TYPES().values()
+            if isinstance(group, dict)
+            for name in group
+        }
+        assert set(node["inputs"]) <= declared

--- a/tests/test_video_intelligence.py
+++ b/tests/test_video_intelligence.py
@@ -1,0 +1,378 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import torch
+
+from ComfyUI_VLM_nodes.nodes.video_intelligence import (
+    NODE_CLASS_MAPPINGS,
+    VLMAdaptiveFrameSampler,
+    build_scene_state,
+    build_video_reasoning_prompt,
+    parse_video_reasoning_output,
+    resize_video_for_analysis,
+    sample_video_frames,
+    scene_state_summary,
+    track_aware_crops,
+)
+from ComfyUI_VLM_nodes.nodes.vision_types import (
+    Detection,
+    EventSequence,
+    SceneState,
+    SelectedVideoFrame,
+    Track,
+    TrackSequence,
+    VideoFrameSelection,
+)
+
+
+def _moving_video(frame_count=20, height=48, width=64):
+    frames = torch.zeros((frame_count, height, width, 3), dtype=torch.float32)
+    for frame_index in range(frame_count):
+        x = min(width - 9, 2 + frame_index * 2)
+        frames[frame_index, 16:28, x : x + 8, 0] = 1.0
+        if frame_index >= frame_count // 2:
+            frames[frame_index, :, :, 2] += 0.55
+    return frames.clamp(0, 1)
+
+
+def _tracks(width=64, height=48, frame_count=20, fps=10.0):
+    detections = []
+    for frame_index in (0, 5, 10, 15, 19):
+        x = min(width - 12, 2 + frame_index * 2)
+        detections.append(
+            Detection(
+                bbox_xyxy=(x, 14, x + 10, 30),
+                label="red object",
+                score=0.9 - frame_index * 0.005,
+                frame_index=frame_index,
+                timestamp=frame_index / fps,
+                track_id=3,
+                metadata={"track_state": "active"},
+            )
+        )
+    return TrackSequence(
+        width=width,
+        height=height,
+        frame_count=frame_count,
+        fps=fps,
+        tracks=(
+            Track(
+                track_id=3,
+                detections=tuple(detections),
+                label="red object",
+                score=0.85,
+            ),
+        ),
+        source="unit-test-tracker",
+    )
+
+
+def _selection():
+    return VideoFrameSelection(
+        width=64,
+        height=48,
+        source_frame_count=20,
+        fps=10.0,
+        strategy="Hybrid: scene + motion + tracks",
+        frames=(
+            SelectedVideoFrame(0, 0.0, 1.0, ("first-frame",)),
+            SelectedVideoFrame(5, 0.5, 0.7, ("motion",)),
+            SelectedVideoFrame(10, 1.0, 0.9, ("scene-change",)),
+            SelectedVideoFrame(19, 1.9, 1.0, ("last-frame",)),
+        ),
+    )
+
+
+def test_uniform_sampling_is_deterministic_and_preserves_timestamps():
+    frames = _moving_video()
+    sampled, selection, diagnostics = sample_video_frames(
+        frames,
+        fps=10.0,
+        max_frames=5,
+        strategy="Uniform coverage",
+    )
+    assert sampled.shape == (5, 48, 64, 3)
+    assert selection.indices == (0, 5, 10, 14, 19)
+    assert selection.timestamps == pytest.approx((0.0, 0.5, 1.0, 1.4, 1.9))
+    assert diagnostics["visual_reduction_ratio"] == pytest.approx(0.75)
+    assert torch.equal(sampled[2], frames[10])
+
+
+def test_hybrid_sampling_captures_boundaries_scene_change_and_motion():
+    frames = _moving_video()
+    sampled, selection, diagnostics = sample_video_frames(
+        frames,
+        fps=10.0,
+        max_frames=7,
+        strategy="Hybrid: scene + motion + tracks",
+        minimum_gap_seconds=0.2,
+    )
+    assert sampled.shape[0] == 7
+    assert selection.indices[0] == 0
+    assert selection.indices[-1] == 19
+    assert any(9 <= index <= 11 for index in selection.indices)
+    assert diagnostics["motion_peak"] > 0
+    assert diagnostics["scene_peak"] > 0
+    assert selection.to_json() == VideoFrameSelection.from_json(
+        selection.to_json()
+    ).to_json()
+
+
+def test_track_priority_uses_track_changes_and_validates_dimensions():
+    frames = _moving_video()
+    tracks = _tracks()
+    _sampled, selection, diagnostics = sample_video_frames(
+        frames,
+        fps=10.0,
+        max_frames=6,
+        strategy="Track-change priority",
+        tracks=tracks,
+    )
+    assert diagnostics["track_peak"] == pytest.approx(1.0)
+    assert any(
+        "track-change" in frame.reasons for frame in selection.frames
+    )
+    bad_tracks = TrackSequence(
+        width=65,
+        height=48,
+        frame_count=20,
+        fps=10,
+        tracks=(),
+    )
+    with pytest.raises(ValueError, match="dimensions"):
+        sample_video_frames(
+            frames,
+            fps=10,
+            max_frames=4,
+            tracks=bad_tracks,
+        )
+
+
+@pytest.mark.parametrize(
+    "frames",
+    [
+        torch.zeros(4, 16, 16),
+        torch.zeros(4, 16, 16, 2),
+        torch.zeros(0, 16, 16, 3),
+        torch.zeros(4, 16, 16, 3, dtype=torch.uint8),
+    ],
+)
+def test_sampling_rejects_invalid_video_tensors(frames):
+    with pytest.raises((TypeError, ValueError)):
+        sample_video_frames(frames, fps=24, max_frames=4)
+
+
+def test_track_aware_crops_preserve_identity_and_source_frame_mapping():
+    frames = _moving_video()
+    crops, manifest = track_aware_crops(
+        frames,
+        _tracks(),
+        crops_per_track=3,
+        max_crops=8,
+        output_size=96,
+        context_scale=1.4,
+    )
+    assert crops.shape == (3, 96, 96, 3)
+    assert [item["track_id"] for item in manifest] == [3, 3, 3]
+    assert [item["source_frame_index"] for item in manifest] == [0, 10, 19]
+    assert crops.max().item() > 0.5
+
+
+def test_analysis_resize_reduces_pixels_without_changing_batch_or_aspect():
+    frames = _moving_video(height=128, width=256)
+    resized = resize_video_for_analysis(frames, max_side=128)
+    assert resized.shape == (20, 64, 128, 3)
+    assert resized.min().item() >= 0
+    assert resized.max().item() <= 1
+    assert resize_video_for_analysis(frames, max_side=0) is frames
+
+
+def test_scene_state_ignores_predicted_track_samples_and_computes_velocity():
+    tracks = _tracks()
+    predicted = Detection(
+        bbox_xyxy=(48, 14, 58, 30),
+        label="red object",
+        frame_index=18,
+        timestamp=1.8,
+        track_id=3,
+        metadata={"track_state": "predicted"},
+    )
+    track = tracks.tracks[0]
+    with_prediction = TrackSequence(
+        width=tracks.width,
+        height=tracks.height,
+        frame_count=tracks.frame_count,
+        fps=tracks.fps,
+        tracks=(
+            Track(
+                track_id=3,
+                detections=tuple(
+                    sorted(
+                        (*track.detections, predicted),
+                        key=lambda item: item.frame_index,
+                    )
+                ),
+                label=track.label,
+            ),
+        ),
+    )
+    scene = build_scene_state(with_prediction)
+    assert len(scene.objects) == 1
+    item = scene.objects[0]
+    assert item.observation_count == 5
+    assert item.velocity_xy_px_s[0] > 0
+    assert "#3 red object" in scene_state_summary(scene)
+    assert SceneState.from_json(scene.to_json()).to_json() == scene.to_json()
+
+
+def test_reasoning_prompt_explains_irregular_source_timeline():
+    prompt = build_video_reasoning_prompt(
+        _selection(),
+        task="Robotics scene understanding",
+        question="",
+        max_events=12,
+    )
+    assert "irregularly spaced" in prompt
+    assert "supplied image 2: source frame 10, timestamp 1.000000s" in prompt
+    assert "Do not propose motor commands" in prompt
+    assert "evidence_frame_indices" in prompt
+
+
+def test_structured_video_output_parses_fenced_json_and_preserves_evidence():
+    response = """Result:
+```json
+{
+  "summary": "A red object moves to the right.",
+  "events": [
+    {
+      "start_time": 0.0,
+      "end_time": 1.9,
+      "label": "object motion",
+      "text": "The red object moves from left to right.",
+      "score": 0.94,
+      "evidence_frame_indices": [0, 10, 19]
+    }
+  ]
+}
+```
+"""
+    summary, events, normalized = parse_video_reasoning_output(
+        response,
+        _selection(),
+    )
+    assert summary == "A red object moves to the right."
+    assert len(events.events) == 1
+    assert events.events[0].metadata["evidence_frame_indices"] == (0, 10, 19)
+    assert json.loads(normalized)["events"][0]["label"] == "object motion"
+
+
+def test_structured_output_normalizes_supplied_image_positions_to_source_frames():
+    response = json.dumps(
+        {
+            "summary": "A transition occurs.",
+            "events": [
+                {
+                    "start_time": 0.5,
+                    "end_time": 1.9,
+                    "label": "transition",
+                    "text": "The scene changes.",
+                    "score": 0.8,
+                    # Positions 1 and 3 in the supplied image batch.
+                    "evidence_frame_indices": [1, 3],
+                }
+            ],
+        }
+    )
+    _summary, events, _normalized = parse_video_reasoning_output(
+        response,
+        _selection(),
+    )
+    event = events.events[0]
+    assert event.metadata["evidence_frame_indices"] == (5, 19)
+    assert event.metadata["evidence_index_mode"] == "supplied-image-position"
+
+
+@pytest.mark.parametrize(
+    ("event_patch", "error"),
+    [
+        ({"end_time": 2.1}, "outside"),
+        ({"score": 1.2}, "between"),
+        ({"evidence_frame_indices": [0, 7]}, "not supplied"),
+        ({"evidence_frame_indices": [0, 0]}, "duplicate"),
+        ({"label": "", "text": ""}, "requires"),
+    ],
+)
+def test_structured_video_output_rejects_unverifiable_events(event_patch, error):
+    event = {
+        "start_time": 0.0,
+        "end_time": 1.0,
+        "label": "motion",
+        "text": "Object moves.",
+        "score": 0.8,
+        "evidence_frame_indices": [0, 10],
+    }
+    event.update(event_patch)
+    with pytest.raises((TypeError, ValueError), match=error):
+        parse_video_reasoning_output(
+            json.dumps({"summary": "test", "events": [event]}),
+            _selection(),
+        )
+
+
+def test_scene_state_accepts_validated_events():
+    _summary, events, _normalized = parse_video_reasoning_output(
+        json.dumps(
+            {
+                "summary": "motion",
+                "events": [
+                    {
+                        "start_time": 0.0,
+                        "end_time": 1.9,
+                        "label": "motion",
+                        "text": "Object moves.",
+                        "score": 0.9,
+                        "evidence_frame_indices": [0, 19],
+                    }
+                ],
+            }
+        ),
+        _selection(),
+    )
+    scene = build_scene_state(_tracks(), events)
+    assert isinstance(events, EventSequence)
+    assert len(scene.events) == 1
+    assert "Event 0.000s–1.900s" in scene_state_summary(scene)
+
+
+def test_node_surface_registers_all_video_intelligence_nodes():
+    assert set(NODE_CLASS_MAPPINGS) == {
+        "VLMAdaptiveFrameSampler",
+        "VLMTrackAwareCrops",
+        "VLMBuildSceneState",
+        "VLMVideoReasoningPrompt",
+        "VLMEventsFromVideoJSON",
+        "VLMVideoTemporalReasoner",
+    }
+    inputs = VLMAdaptiveFrameSampler.INPUT_TYPES()
+    assert inputs["required"]["frames"][0] == "IMAGE"
+    assert inputs["optional"]["tracks"][0] == "VLM_TRACKS"
+    reasoner = NODE_CLASS_MAPPINGS["VLMVideoTemporalReasoner"]
+    assert reasoner.RETURN_NAMES[-2:] == ("events_json", "selection_json")
+
+
+def test_api_example_uses_direct_json_outputs_and_preview():
+    example = json.loads(
+        (
+            Path(__file__).resolve().parents[1]
+            / "examples"
+            / "vision"
+            / "video_temporal_reasoning_api.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert example["3"]["class_type"] == "VLMVideoTemporalReasoner"
+    assert example["5"]["inputs"]["text"] == ["3", 6]
+    assert example["6"]["inputs"]["text"] == ["3", 7]
+    assert example["8"]["inputs"]["images"] == ["3", 3]

--- a/tests/test_vision_types.py
+++ b/tests/test_vision_types.py
@@ -13,11 +13,15 @@ DETECTIONS_SCHEMA = vision_types.DETECTIONS_SCHEMA
 EVENTS_SCHEMA = vision_types.EVENTS_SCHEMA
 POINTS_SCHEMA = vision_types.POINTS_SCHEMA
 SCHEMA_VERSION = vision_types.SCHEMA_VERSION
+SCENE_STATE_SCHEMA = vision_types.SCENE_STATE_SCHEMA
 TRACKS_SCHEMA = vision_types.TRACKS_SCHEMA
+VIDEO_SELECTION_SCHEMA = vision_types.VIDEO_SELECTION_SCHEMA
 VLM_DETECTIONS = vision_types.VLM_DETECTIONS
 VLM_EVENTS = vision_types.VLM_EVENTS
 VLM_POINTS = vision_types.VLM_POINTS
+VLM_SCENE_STATE = vision_types.VLM_SCENE_STATE
 VLM_TRACKS = vision_types.VLM_TRACKS
+VLM_VIDEO_SELECTION = vision_types.VLM_VIDEO_SELECTION
 Detection = vision_types.Detection
 DetectionSequence = vision_types.DetectionSequence
 EventSequence = vision_types.EventSequence
@@ -86,11 +90,15 @@ def test_public_socket_and_schema_names_are_stable():
     assert VLM_TRACKS == "VLM_TRACKS"
     assert VLM_POINTS == "VLM_POINTS"
     assert VLM_EVENTS == "VLM_EVENTS"
+    assert VLM_VIDEO_SELECTION == "VLM_VIDEO_SELECTION"
+    assert VLM_SCENE_STATE == "VLM_SCENE_STATE"
     assert SCHEMA_VERSION == 1
     assert DETECTIONS_SCHEMA == "comfyui-vlm/detections"
     assert TRACKS_SCHEMA == "comfyui-vlm/tracks"
     assert POINTS_SCHEMA == "comfyui-vlm/points"
     assert EVENTS_SCHEMA == "comfyui-vlm/events"
+    assert VIDEO_SELECTION_SCHEMA == "comfyui-vlm/video-selection"
+    assert SCENE_STATE_SCHEMA == "comfyui-vlm/scene-state"
 
 
 def test_detection_payload_is_validated_immutable_and_mask_safe():

--- a/web/js/viewText.js
+++ b/web/js/viewText.js
@@ -7,83 +7,145 @@ const STREAMING_SOURCE_NODES = new Set([
     "ModernVLM",
     "PromptGenerateAPI",
     "HostedVLMAPI",
+    "VLMVideoTemporalReasoner",
 ]);
+
+function textMetrics(value) {
+    const text = String(value ?? "");
+    const words = text.trim() ? text.trim().split(/\s+/u).length : 0;
+    const lines = text ? text.split("\n").length : 0;
+    return `${text.length.toLocaleString()} chars · ${words.toLocaleString()} words · ${lines.toLocaleString()} lines`;
+}
+
+function makeButton(label, title, handler) {
+    const button = document.createElement("button");
+    button.textContent = label;
+    button.type = "button";
+    button.title = title;
+    button.addEventListener("click", handler);
+    Object.assign(button.style, {
+        color: "var(--input-text, #ddd)",
+        background: "var(--comfy-input-bg, #202020)",
+        border: "1px solid var(--border-color, #555)",
+        borderRadius: "5px",
+        padding: "3px 8px",
+        cursor: "pointer",
+        whiteSpace: "nowrap",
+    });
+    return button;
+}
 
 function ensureOutputWidget(node) {
     let widget = node.widgets?.find((item) => item.name === OUTPUT_NAME);
-    if (!widget) {
-        const container = document.createElement("div");
-        const header = document.createElement("div");
-        const status = document.createElement("span");
-        const copy = document.createElement("button");
-        const output = document.createElement("textarea");
-
-        status.textContent = "Ready";
-        copy.textContent = "Copy";
-        copy.type = "button";
-        copy.title = "Copy the complete VLM response";
-        copy.addEventListener("click", async () => {
-            const previous = copy.textContent;
-            try {
-                await navigator.clipboard.writeText(output.value);
-                copy.textContent = "Copied";
-            } catch {
-                copy.textContent = "Copy failed";
-            }
-            window.setTimeout(() => {
-                copy.textContent = previous;
-            }, 1200);
-        });
-
-        output.readOnly = true;
-        output.setAttribute("aria-label", "VLM text output");
-        header.append(status, copy);
-        container.append(header, output);
-        Object.assign(container.style, {
-            display: "flex",
-            flexDirection: "column",
-            width: "100%",
-            height: "100%",
-            minHeight: "150px",
-            gap: "6px",
-        });
-        Object.assign(header.style, {
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            color: "var(--descrip-text, #aaa)",
-            fontSize: "12px",
-        });
-        Object.assign(copy.style, {
-            color: "var(--input-text, #ddd)",
-            background: "var(--comfy-input-bg, #202020)",
-            border: "1px solid var(--border-color, #555)",
-            borderRadius: "5px",
-            padding: "3px 9px",
-            cursor: "pointer",
-        });
-        Object.assign(output.style, {
-            width: "100%",
-            flex: "1",
-            minHeight: "120px",
-            resize: "vertical",
-            boxSizing: "border-box",
-            color: "var(--input-text, #ddd)",
-            background: "var(--comfy-input-bg, #202020)",
-            border: "1px solid var(--border-color, #555)",
-            borderRadius: "6px",
-            padding: "8px",
-            lineHeight: "1.45",
-            whiteSpace: "pre-wrap",
-        });
-        widget = node.addDOMWidget(OUTPUT_NAME, "STRING", container, {
-            serialize: false,
-            hideOnZoom: false,
-        });
-        widget.serialize = false;
-        widget.inputEl = output;
-        widget.statusEl = status;
+    if (widget) {
+        return widget;
     }
+
+    const container = document.createElement("div");
+    const header = document.createElement("div");
+    const status = document.createElement("span");
+    const meta = document.createElement("span");
+    const actions = document.createElement("div");
+    const output = document.createElement("textarea");
+
+    status.textContent = "Ready";
+    meta.textContent = textMetrics("");
+    output.readOnly = true;
+    output.wrap = "soft";
+    output.spellcheck = false;
+    output.setAttribute("aria-label", "VLM text output");
+
+    const copy = makeButton("Copy", "Copy complete text", async () => {
+        const previous = copy.textContent;
+        try {
+            await navigator.clipboard.writeText(output.value);
+            copy.textContent = "Copied";
+        } catch {
+            copy.textContent = "Copy failed";
+        }
+        window.setTimeout(() => {
+            copy.textContent = previous;
+        }, 1200);
+    });
+    const download = makeButton("Save", "Download output as a UTF-8 text file", () => {
+        const blob = new Blob([output.value], {
+            type: "text/plain;charset=utf-8",
+        });
+        const url = URL.createObjectURL(blob);
+        const anchor = document.createElement("a");
+        anchor.href = url;
+        anchor.download = `vlm-output-${new Date().toISOString().replaceAll(":", "-")}.txt`;
+        anchor.click();
+        URL.revokeObjectURL(url);
+    });
+    const wrap = makeButton("Wrap: on", "Toggle long-line wrapping", () => {
+        const enabled = output.wrap !== "off";
+        output.wrap = enabled ? "off" : "soft";
+        output.style.whiteSpace = enabled ? "pre" : "pre-wrap";
+        output.style.overflowX = enabled ? "auto" : "hidden";
+        wrap.textContent = enabled ? "Wrap: off" : "Wrap: on";
+    });
+    const follow = makeButton("Follow: on", "Follow streaming output", () => {
+        widget.followOutput = !widget.followOutput;
+        follow.textContent = widget.followOutput ? "Follow: on" : "Follow: off";
+    });
+
+    actions.append(wrap, follow, copy, download);
+    header.append(status, meta, actions);
+    container.append(header, output);
+
+    Object.assign(container.style, {
+        display: "flex",
+        flexDirection: "column",
+        width: "100%",
+        height: "100%",
+        minHeight: "190px",
+        gap: "6px",
+    });
+    Object.assign(header.style, {
+        display: "grid",
+        gridTemplateColumns: "auto minmax(0, 1fr) auto",
+        alignItems: "center",
+        gap: "9px",
+        color: "var(--descrip-text, #aaa)",
+        fontSize: "11px",
+    });
+    Object.assign(meta.style, {
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        whiteSpace: "nowrap",
+    });
+    Object.assign(actions.style, {
+        display: "flex",
+        gap: "4px",
+        justifyContent: "flex-end",
+    });
+    Object.assign(output.style, {
+        width: "100%",
+        flex: "1",
+        minHeight: "160px",
+        resize: "vertical",
+        boxSizing: "border-box",
+        color: "var(--input-text, #ddd)",
+        background: "var(--comfy-input-bg, #202020)",
+        border: "1px solid var(--border-color, #555)",
+        borderRadius: "6px",
+        padding: "9px",
+        lineHeight: "1.45",
+        whiteSpace: "pre-wrap",
+        overflowWrap: "anywhere",
+        tabSize: "4",
+    });
+
+    widget = node.addDOMWidget(OUTPUT_NAME, "STRING", container, {
+        serialize: false,
+        hideOnZoom: false,
+    });
+    widget.serialize = false;
+    widget.inputEl = output;
+    widget.statusEl = status;
+    widget.metaEl = meta;
+    widget.followOutput = true;
     return widget;
 }
 
@@ -92,8 +154,10 @@ function setOutput(node, text, state = "Complete") {
     const value = Array.isArray(text) ? text.join("\n\n") : String(text ?? "");
     widget.value = value;
     widget.inputEl.value = value;
-    if (widget.statusEl) {
-        widget.statusEl.textContent = state;
+    widget.statusEl.textContent = state;
+    widget.metaEl.textContent = textMetrics(value);
+    if (widget.followOutput && state === "Streaming…") {
+        widget.inputEl.scrollTop = widget.inputEl.scrollHeight;
     }
     node.setDirtyCanvas?.(true, true);
 }
@@ -108,18 +172,38 @@ function findNode(graph, id) {
         ?? null;
 }
 
+function linkFor(graph, linkId) {
+    return graph?.links?.get?.(linkId)
+        ?? graph?._links?.get?.(linkId)
+        ?? null;
+}
+
+function isReroute(node) {
+    return String(node?.type ?? "").toLowerCase().includes("reroute");
+}
+
 function connectedViewTextNodes(source) {
     if (!source?.graph) {
         return [];
     }
     const found = new Set();
-    for (const output of source.outputs ?? []) {
-        for (const linkId of output.links ?? []) {
-            const link = source.graph.links?.get?.(linkId)
-                ?? source.graph._links?.get?.(linkId);
-            const target = findNode(source.graph, link?.target_id);
-            if (target?.type === VIEW_TEXT_NODE) {
-                found.add(target);
+    const visited = new Set([source.id]);
+    const queue = [source];
+    while (queue.length) {
+        const current = queue.shift();
+        for (const output of current.outputs ?? []) {
+            for (const linkId of output.links ?? []) {
+                const link = linkFor(source.graph, linkId);
+                const target = findNode(source.graph, link?.target_id);
+                if (!target || visited.has(target.id)) {
+                    continue;
+                }
+                visited.add(target.id);
+                if (target.type === VIEW_TEXT_NODE) {
+                    found.add(target);
+                } else if (isReroute(target)) {
+                    queue.push(target);
+                }
             }
         }
     }
@@ -158,6 +242,12 @@ app.registerExtension({
         nodeType.prototype.onNodeCreated = function (...args) {
             const result = onCreated?.apply(this, args);
             ensureOutputWidget(this);
+            if (Array.isArray(this.size)) {
+                this.setSize?.([
+                    Math.max(this.size[0], 430),
+                    Math.max(this.size[1], 290),
+                ]);
+            }
             return result;
         };
         const onExecuted = nodeType.prototype.onExecuted;


### PR DESCRIPTION
## What changed

- adds adaptive scene/motion/track-aware video sampling, track crops, persistent scene state, strict temporal event parsing, and a one-node video reasoner
- curates the Modern VLM picker to 12 production choices while preserving all old ModernVLM workflow values through a 14-choice Legacy compatibility loader
- moves Molmo and other superseded dedicated loaders under Legacy without changing their node IDs
- upgrades SimpleText, JsonToText, and ViewText compatibly and adds join, template, clean, replace, JSON extract, text batch/split, and inspector nodes
- expands ViewText with streaming through reroutes, copy, download, wrap/follow controls, counts, and output-history rehydration
- packages API examples and bumps the node pack to 3.2.0

## Verification

- 173 pytest tests pass
- Python compileall and git diff --check pass
- frontend JavaScript passes node --check
- sdist and wheel build successfully; installed wheel imports all 70 nodes and includes examples
- live ComfyUI object_info reports 12 Modern choices, 14 Legacy choices, Molmo under Legacy, and all new text/video nodes
- live text toolkit API prompt completes successfully with no node errors
- real 157-frame H.264 clip tested with Qwen3-VL 2B through standalone and live ComfyUI API paths; 12 adaptive frames, valid structured event output, about 4.24 GiB peak allocated VRAM

The real small-model result correctly described the train conversation but over-inferred one attire detail; structural validation is strict, while semantic truth still benefits from model escalation on difficult scenes.
