### PR TITLE
Add Moondream Photon and universal VLM acceleration

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -49,6 +49,33 @@ cannot execute BF16. This is a portability fallback, not proof that every
 model family has been run on every vendor device. See
 [MODEL_VALIDATION.md](MODEL_VALIDATION.md) for real-hardware evidence.
 
+### Moondream 3 / 3.1 Photon
+
+Moondream Photon is deliberately isolated from ComfyUI's main Python environment
+because `moondream==1.3.0` requires Pillow 10 while current ComfyUI uses a
+newer Pillow. Its worker cache, virtual environment, and logs live under
+`models/LLavacheckpoints/moondream31-runtime`; it never replaces ComfyUI's
+PyTorch or Pillow.
+
+| Platform | Official local Photon support | This integration |
+| --- | --- | --- |
+| Linux/WSL + NVIDIA Ampere or newer | Supported | 3.1 query/caption/detection/pointing; 3 Preview SVG segmentation |
+| Windows + NVIDIA Ampere or newer | Supported | Same isolated worker contract |
+| Apple Silicon macOS 13+ | Supported with MPS | Same contract; use a conservative KV-cache profile on low-memory systems |
+| AMD ROCm, Intel GPU, CPU | Not currently provided upstream | Node stays importable and fails before model work with an actionable support message |
+
+The final Moondream 3.1 model card lists query, caption, detect, and point; it
+does not list segment. Native SVG segment uses `moondream3-preview`, and the
+loader rejects a 3.1/segment mismatch before inference.
+
+`max_batch_size` controls Photon's scheduler capacity. The detection, point,
+and preview-segmentation nodes issue `parallel_requests` frame requests concurrently,
+allowing Photon to build GPU batches. `frame_stride` bounds work for high-frame
+rate sources. Performance JSON records warm worker time, end-to-end time,
+processed/skipped frames, worker/sustained FPS, target sampled FPS, and
+real-time factor; it is a measurement from the current run, not a universal
+benchmark claim.
+
 ### Video memory and chunking
 
 - Core `Video Slice` should bound work before `GetVideoComponents` materializes
@@ -81,6 +108,10 @@ model card before redistributing weights or outputs.
   `ComfyUI/models/checkpoints`.
 - `HF_TOKEN` is used when Hugging Face requires authenticated access. Tokens
   must be supplied by the environment and must not be embedded in workflows.
+- Moondream 3.1 uses the Moondream Model License 1.0. The Loader requires an
+  explicit workflow acknowledgement. The license permits local product use
+  but restricts offering general-purpose hosted Moondream access; review the
+  current upstream terms for the intended deployment.
 
 Authoritative references:
 
@@ -88,6 +119,8 @@ Authoritative references:
 - [Meta SAM3 license](https://huggingface.co/facebook/sam3/blob/main/LICENSE)
 - [ComfyUI SAM3.1 checkpoint](https://huggingface.co/Comfy-Org/sam3.1)
 - [SAM2.1 Hiera Tiny model card](https://huggingface.co/facebook/sam2.1-hiera-tiny)
+- [Moondream 3.1 model card](https://huggingface.co/moondream/moondream3.1-9B-A2B)
+- [Moondream Model License 1.0](https://moondream.ai/licenses/model/1.0)
 
 ## Dependency behavior
 
@@ -99,6 +132,8 @@ Authoritative references:
   from blocking the whole node pack.
 - `requirements-quantization.txt` is available for an explicit quantization
   install or source-build environment.
+- `requirements-moondream31.txt` belongs only in the isolated Photon sidecar;
+  installing it into ComfyUI's environment would create a Pillow conflict.
 - Model downloads, imports, and package compilation never occur during node
   discovery.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ComfyUI VLM Nodes
 
 Production-oriented vision-language, structured prompting, audio, and utility
-nodes for ComfyUI. Version 3.2 supports ComfyUI's selected NVIDIA CUDA, AMD
+nodes for ComfyUI. Version 3.3 supports ComfyUI's selected NVIDIA CUDA, AMD
 ROCm, Apple Metal, Intel XPU, and CPU device without replacing its PyTorch
 build. It removes startup installers and global accelerator cache flushes,
 adds real image/video batches and live token streaming, and uses ComfyUI model
@@ -91,6 +91,14 @@ or context accounting matters.
 Specialized nodes remain available where a generic chat node would discard
 useful model capabilities:
 
+- **Moondream 3.1 9B-A2B**: official 2B-active Photon runtime with query,
+  caption, and high-throughput image/video detection and pointing.
+- **Moondream 3 Preview segment**: native SVG segmentation through the same
+  isolated Photon loader. The SVG is preserved and also converted into antialiased
+  `MASK`, black/white previews, foreground cutouts, overlays, polygons,
+  canonical `VLM_DETECTIONS`, and core bounding boxes. Detection/pointing
+  submit frames concurrently so Photon can dynamically batch them; every run
+  reports measured worker FPS, end-to-end FPS, and real-time factor.
 - **Florence-2**: captioning, OCR, detection, region captioning, and referring
   expression segmentation, with structured JSON, mask, and overlay outputs.
 - **PaLI-Gemma**: caption/VQA plus the official 16-token VQ-VAE segmentation
@@ -149,6 +157,39 @@ The utility layer converts without model-specific glue:
   background broadcasts safely across a video batch.
 - `VLMDetectionsFromJSON` and `VLMDetectionsToJSON` are the explicit API and
   persistence boundary for the versioned detection schema.
+
+### Universal VLM performance utilities
+
+The performance nodes sit before any local or hosted VLM, so their savings do
+not depend on CUDA, ROCm, MPS, XPU, CPU, Transformers, llama.cpp, or Photon:
+
+- `VLM Performance Profile` emits coherent `max_frames`, pixel budget,
+  longest-edge, batch-size, and `unload_after` values. `Live / robotics`,
+  `Fast video`, `Balanced`, `High detail`, and `Low VRAM handoff` are explicit
+  starting points rather than hidden global flags.
+- `VLM Adaptive Frame Sampler` is the existing track-aware temporal gate. It
+  combines uniform coverage, scene changes, motion, and optional track changes
+  while preserving source frame indices and timestamps.
+- `VLM Image Pixel Budget` downsizes the selected analysis copy once, preserves
+  aspect ratio, never upscales, and can align dimensions to 14/28-pixel VLM
+  patches or 32-pixel detector backbones. Fast area and antialiased bicubic
+  modes are available.
+
+The recommended order is `Video Slice` → `VLM Adaptive Frame Sampler` →
+`VLM Image Pixel Budget` → any VLM. A model's own official processor still
+performs its required normalization/crop; the pixel-budget node simply prevents
+every downstream model from repeatedly receiving unnecessary source pixels.
+Local torch models remain registered with ComfyUI's smart model manager, while
+external allocators reserve space before loading and close only the handle they
+own.
+
+On the real `vlm_api_people_birds.mp4` input in this repository's D-drive test
+environment, the utilities selected 10 of 60 1280×720 frames and resized them
+to 938×518 in about 0.44 seconds on a cold WSL run. That reduced the
+frame×pixel analysis workload by 11.38× before model inference. This is an
+input-work reduction measurement, not a claim that every model runs 11.38×
+faster; token generation and model-specific vision encoders still determine
+end-to-end speed.
 
 ### Adaptive video intelligence
 
@@ -289,9 +330,12 @@ image visualization. Region tasks reject ambiguous multi-box input; use
 API-format examples are in [`examples/vision`](examples/vision):
 
 - [`grounding_dino_image_api.json`](examples/vision/grounding_dino_image_api.json)
+- [`moondream3_preview_svg_segment_api.json`](examples/vision/moondream3_preview_svg_segment_api.json)
+- [`moondream31_video_detect_api.json`](examples/vision/moondream31_video_detect_api.json)
 - [`sam2_video_tracking_api.json`](examples/vision/sam2_video_tracking_api.json)
 - [`sam3_core_adapter_blueprint_api.json`](examples/vision/sam3_core_adapter_blueprint_api.json)
 - [`video_temporal_reasoning_api.json`](examples/vision/video_temporal_reasoning_api.json)
+- [`vlm_performance_preflight_api.json`](examples/vision/vlm_performance_preflight_api.json)
 
 The dependency-free text-toolkit example is
 [`examples/text_toolkit_api.json`](examples/text_toolkit_api.json).
@@ -313,6 +357,45 @@ this repository: ComfyUI's own installer selects CUDA, ROCm, XPU, Metal, or CPU.
 Current official bitsandbytes wheels are installed automatically only on their
 supported OS/architecture combinations. Unsupported machines retain all
 non-quantized nodes.
+
+### Moondream 3 / 3.1 isolated runtime
+
+Moondream's official Photon package pins Pillow below version 11 while
+current ComfyUI uses a newer Pillow. It therefore runs in a dedicated sidecar
+environment and never changes ComfyUI's Python packages. Read and accept the
+[Moondream Model License 1.0](https://moondream.ai/licenses/model/1.0), then
+create the environment under the registered `LLavacheckpoints` model folder.
+
+Linux/WSL/macOS:
+
+```bash
+runtime="ComfyUI/models/LLavacheckpoints/moondream31-runtime"
+uv venv "$runtime/.venv" --python 3.12
+uv pip install --python "$runtime/.venv/bin/python" \
+  -r ComfyUI/custom_nodes/ComfyUI_VLM_nodes/requirements-moondream31.txt
+```
+
+Windows PowerShell:
+
+```powershell
+$runtime = "ComfyUI\models\LLavacheckpoints\moondream31-runtime"
+uv venv "$runtime\.venv" --python 3.12
+uv pip install --python "$runtime\.venv\Scripts\python.exe" `
+  -r "ComfyUI\custom_nodes\ComfyUI_VLM_nodes\requirements-moondream31.txt"
+```
+
+The first Loader execution downloads the selected official model below that
+runtime's `cache` directory. Use `moondream3.1-9B-A2B` for query, caption,
+detection, and pointing. Use `moondream3-preview` only for the SVG segment
+skill; the final 3.1 model card does not list segment. Set the server-side
+`MOONDREAM_PYTHON` environment variable
+when using a different isolated environment. Do not put this path or any
+credential in a workflow.
+
+Official Photon local inference currently supports NVIDIA Ampere-or-newer on
+Linux/Windows and Apple Silicon on macOS 13 or newer. It does not currently
+provide local ROCm, Intel GPU, or CPU execution. Those platforms retain every
+portable Transformers, GGUF, API, and vision utility node in this pack.
 
 GGUF nodes use optional `llama-cpp-python`. Install a wheel built for the
 desired CUDA, ROCm/HIP, Metal, Vulkan, SYCL, or CPU backend:
@@ -357,7 +440,17 @@ Gemma 3 and PaLI-Gemma require accepting their model licenses on Hugging Face.
   The runtime reports llama.cpp's own compiled backend, GPU-offload, mmap, and
   mlock capabilities in **VLM Runtime Diagnostics**.
 - `unload_after=false` caches one model per node instance for fast repeated
-  queues. Turn it on for maximum reclamation between prompts.
+  queues. Cache creation is serialized, so concurrent API work cannot make the
+  same node allocate duplicate model handles. Turn it on for maximum
+  reclamation between prompts.
+- Moondream Photon asks ComfyUI to make room before it starts, then owns one
+  exact isolated process. `unload_after=true` gracefully shuts it down and
+  terminates that process if necessary, which releases Photon model, KV-cache,
+  and CUDA-graph allocations without flushing unrelated ComfyUI models. The
+  worker does not inherit unrelated provider keys or proxy credentials; only
+  `HF_TOKEN`, and `MOONDREAM_API_KEY` for an explicitly selected adapter, may
+  cross into its server-side environment. Its random IPC secret is not placed
+  on the process command line.
 - A connected `video_frames` batch becomes the primary visual input. The
   optional still-image socket is ignored for video inference so smaller models
   cannot silently answer from the wrong media.

--- a/__init__.py
+++ b/__init__.py
@@ -7,6 +7,7 @@ LOGGER = logging.getLogger("ComfyUI_VLM_nodes")
 register_model_folder()
 
 node_list = [
+    "acceleration",
     "audioldm2",
     "diagnostics",
     "florence2",
@@ -19,6 +20,7 @@ node_list = [
     "minicpm",
     "modern_vlm",
     "molmo",
+    "moondream31",
     "moondream2",
     "moondream_script",
     "paligemma",

--- a/examples/vision/README.md
+++ b/examples/vision/README.md
@@ -29,6 +29,38 @@ Runs Grounding DINO Tiny over `grounding_input.png`. Node 2 outputs:
 
 `PreviewImage` displays output 2 and `ViewText` reports output 1.
 
+### `vlm_performance_preflight_api.json`
+
+Loads `vlm_api_people_birds.mp4` with Comfy core video nodes, applies the
+`Fast video` performance profile, runs the track-aware adaptive sampler, and
+then applies a 14-pixel-aligned image budget. The preview shows the exact batch
+that can be connected to any local or hosted VLM. Three `ViewText` nodes report
+the selected source indices/timestamps, pixel reduction, and active profile.
+
+### `moondream3_preview_svg_segment_api.json`
+
+Runs the official Moondream 3 Preview SVG segmentation skill over
+`moondream_segment_input.png`. Read the linked model license and change
+`license_accepted` to `true` before queueing. The graph previews the
+black/white mask, isolated foreground cutout, and mask/box/polygon overlay;
+`ViewText` receives the exact native SVG path plus its normalized bbox.
+
+Moondream's path coordinates are normalized within the returned bbox. The
+node preserves that path verbatim, safely flattens curves/arcs, applies an
+even-odd fill for subpath holes, and supersamples the raster edge. The
+canonical detection keeps both the primary polygon and the full in-process
+mask.
+
+### `moondream31_video_detect_api.json`
+
+Loads `moondream_video_input.mp4`, passes the real frame batch and source FPS
+to Moondream, and analyzes every frame with four concurrent requests. Photon
+uses the Loader's `max_batch_size=4` scheduler capacity to form dynamic
+batches. `ViewText` reports measured throughput and real-time factor. Increase
+`frame_stride` to 2, 3, or more when full-frame analysis cannot keep up with
+the source FPS; the canonical results preserve original frame indices and
+timestamps.
+
 ### `sam2_video_tracking_api.json`
 
 Runs this bounded pipeline:

--- a/examples/vision/moondream31_video_detect_api.json
+++ b/examples/vision/moondream31_video_detect_api.json
@@ -1,0 +1,76 @@
+{
+  "1": {
+    "class_type": "LoadVideo",
+    "inputs": {
+      "file": "moondream_video_input.mp4"
+    }
+  },
+  "2": {
+    "class_type": "GetVideoComponents",
+    "inputs": {
+      "video": [
+        "1",
+        0
+      ]
+    }
+  },
+  "3": {
+    "class_type": "Moondream31Loader",
+    "inputs": {
+      "license_accepted": false,
+      "device": "Auto",
+      "max_batch_size": 4,
+      "kv_cache_profile": "Balanced (8K pages)",
+      "model_or_adapter": "moondream3.1-9B-A2B"
+    }
+  },
+  "4": {
+    "class_type": "Moondream31Detect",
+    "inputs": {
+      "model": [
+        "3",
+        0
+      ],
+      "image": [
+        "2",
+        0
+      ],
+      "object": "person",
+      "fps": [
+        "2",
+        2
+      ],
+      "frame_stride": 1,
+      "parallel_requests": 4,
+      "max_objects": 100,
+      "unload_after": false
+    }
+  },
+  "5": {
+    "class_type": "PreviewImage",
+    "inputs": {
+      "images": [
+        "4",
+        2
+      ]
+    }
+  },
+  "6": {
+    "class_type": "ViewText",
+    "inputs": {
+      "text": [
+        "4",
+        6
+      ]
+    }
+  },
+  "7": {
+    "class_type": "ViewText",
+    "inputs": {
+      "text": [
+        "4",
+        1
+      ]
+    }
+  }
+}

--- a/examples/vision/moondream3_preview_svg_segment_api.json
+++ b/examples/vision/moondream3_preview_svg_segment_api.json
@@ -1,0 +1,74 @@
+{
+  "1": {
+    "class_type": "LoadImage",
+    "inputs": {
+      "image": "moondream_segment_input.png"
+    }
+  },
+  "2": {
+    "class_type": "Moondream31Loader",
+    "inputs": {
+      "license_accepted": false,
+      "device": "Auto",
+      "max_batch_size": 4,
+      "kv_cache_profile": "Balanced (8K pages)",
+      "model_or_adapter": "moondream3-preview"
+    }
+  },
+  "3": {
+    "class_type": "Moondream31Segment",
+    "inputs": {
+      "model": [
+        "2",
+        0
+      ],
+      "image": [
+        "1",
+        0
+      ],
+      "object": "main foreground object",
+      "fps": 1.0,
+      "frame_stride": 1,
+      "parallel_requests": 1,
+      "svg_supersample": 4,
+      "unload_after": false,
+      "spatial_refs_json": "[]"
+    }
+  },
+  "4": {
+    "class_type": "PreviewImage",
+    "inputs": {
+      "images": [
+        "3",
+        4
+      ]
+    }
+  },
+  "5": {
+    "class_type": "PreviewImage",
+    "inputs": {
+      "images": [
+        "3",
+        5
+      ]
+    }
+  },
+  "6": {
+    "class_type": "PreviewImage",
+    "inputs": {
+      "images": [
+        "3",
+        6
+      ]
+    }
+  },
+  "7": {
+    "class_type": "ViewText",
+    "inputs": {
+      "text": [
+        "3",
+        2
+      ]
+    }
+  }
+}

--- a/examples/vision/vlm_performance_preflight_api.json
+++ b/examples/vision/vlm_performance_preflight_api.json
@@ -1,0 +1,98 @@
+{
+  "1": {
+    "class_type": "LoadVideo",
+    "inputs": {
+      "file": "vlm_api_people_birds.mp4"
+    }
+  },
+  "2": {
+    "class_type": "GetVideoComponents",
+    "inputs": {
+      "video": [
+        "1",
+        0
+      ]
+    }
+  },
+  "3": {
+    "class_type": "VLMPerformanceProfile",
+    "inputs": {
+      "profile": "Fast video"
+    }
+  },
+  "4": {
+    "class_type": "VLMAdaptiveFrameSampler",
+    "inputs": {
+      "frames": [
+        "2",
+        0
+      ],
+      "fps": [
+        "2",
+        2
+      ],
+      "max_frames": [
+        "3",
+        0
+      ],
+      "strategy": "Hybrid: scene + motion + tracks",
+      "minimum_gap_seconds": 0.15,
+      "thumbnail_size": 96
+    }
+  },
+  "5": {
+    "class_type": "VLMImagePixelBudget",
+    "inputs": {
+      "images": [
+        "4",
+        0
+      ],
+      "max_megapixels": [
+        "3",
+        1
+      ],
+      "max_edge": [
+        "3",
+        2
+      ],
+      "multiple": "14",
+      "resize_quality": "Fast (area)"
+    }
+  },
+  "6": {
+    "class_type": "PreviewImage",
+    "inputs": {
+      "images": [
+        "5",
+        0
+      ]
+    }
+  },
+  "7": {
+    "class_type": "ViewText",
+    "inputs": {
+      "text": [
+        "4",
+        3
+      ]
+    }
+  },
+  "8": {
+    "class_type": "ViewText",
+    "inputs": {
+      "text": [
+        "5",
+        3
+      ]
+    }
+  },
+  "9": {
+    "class_type": "ViewText",
+    "inputs": {
+      "text": [
+        "3",
+        5
+      ]
+    }
+  }
+}

--- a/nodes/acceleration.py
+++ b/nodes/acceleration.py
@@ -1,0 +1,280 @@
+"""Model-agnostic acceleration utilities for image and video VLM workflows.
+
+These nodes reduce visual work *before* it reaches a model. They are therefore
+portable across Transformers, llama.cpp, Photon, hosted APIs, CUDA, ROCm, MPS,
+XPU, and CPU runtimes. No model is downloaded and no global PyTorch setting is
+changed when this module is imported or executed.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Any
+
+import torch
+import torch.nn.functional as functional
+
+
+RESIZE_QUALITY = (
+    "Fast (area)",
+    "Quality (bicubic)",
+)
+PERFORMANCE_PROFILES = {
+    "Live / robotics": {
+        "max_frames": 24,
+        "max_megapixels": 0.5,
+        "max_edge": 896,
+        "batch_size": 8,
+        "unload_after": False,
+    },
+    "Fast video": {
+        "max_frames": 48,
+        "max_megapixels": 0.75,
+        "max_edge": 1024,
+        "batch_size": 8,
+        "unload_after": False,
+    },
+    "Balanced": {
+        "max_frames": 64,
+        "max_megapixels": 1.0,
+        "max_edge": 1344,
+        "batch_size": 4,
+        "unload_after": False,
+    },
+    "High detail": {
+        "max_frames": 96,
+        "max_megapixels": 2.0,
+        "max_edge": 2048,
+        "batch_size": 2,
+        "unload_after": False,
+    },
+    "Low VRAM handoff": {
+        "max_frames": 32,
+        "max_megapixels": 0.75,
+        "max_edge": 1024,
+        "batch_size": 1,
+        "unload_after": True,
+    },
+}
+
+
+def _json(value: Any) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        indent=2,
+    )
+
+
+def _validate_image_batch(images: torch.Tensor) -> tuple[torch.Tensor, bool]:
+    if not isinstance(images, torch.Tensor):
+        raise TypeError("images must be a ComfyUI IMAGE tensor.")
+    single = images.ndim == 3
+    value = images.unsqueeze(0) if single else images
+    if value.ndim != 4:
+        raise ValueError(
+            f"Expected an HWC/BHWC or CHW/BCHW IMAGE tensor, got {tuple(images.shape)}."
+        )
+    if value.shape[-1] in (1, 3, 4):
+        return value, single
+    if value.shape[1] in (1, 3, 4):
+        return value.permute(0, 2, 3, 1), single
+    raise ValueError(f"Unsupported image channel shape: {tuple(images.shape)}.")
+
+
+def optimize_image_pixels(
+    images: torch.Tensor,
+    *,
+    max_megapixels: float,
+    max_edge: int,
+    multiple: int,
+    resize_quality: str,
+) -> tuple[torch.Tensor, dict[str, Any]]:
+    """Downscale a batch once to a bounded visual-token pixel budget."""
+
+    value, single = _validate_image_batch(images)
+    if not math.isfinite(float(max_megapixels)) or max_megapixels <= 0:
+        raise ValueError("max_megapixels must be finite and positive.")
+    if not isinstance(max_edge, int) or max_edge < 32:
+        raise ValueError("max_edge must be at least 32 pixels.")
+    if multiple not in {1, 14, 28, 32}:
+        raise ValueError("multiple must be one of 1, 14, 28, or 32.")
+    if resize_quality not in RESIZE_QUALITY:
+        raise ValueError(f"Unknown resize quality {resize_quality!r}.")
+
+    height, width = int(value.shape[1]), int(value.shape[2])
+    pixel_budget = float(max_megapixels) * 1_000_000
+    scale = min(
+        1.0,
+        float(max_edge) / max(width, height),
+        math.sqrt(pixel_budget / (width * height)),
+    )
+
+    def bounded_dimension(dimension: int) -> int:
+        target = max(1, math.floor(dimension * scale))
+        if multiple == 1 or target < multiple:
+            return target
+        return max(multiple, (target // multiple) * multiple)
+
+    output_width = bounded_dimension(width)
+    output_height = bounded_dimension(height)
+    output = value
+    resized_image = (output_height, output_width) != (height, width)
+    if resized_image:
+        nchw = value.permute(0, 3, 1, 2)
+        if resize_quality == "Fast (area)":
+            resized = functional.interpolate(
+                nchw,
+                size=(output_height, output_width),
+                mode="area",
+            )
+        else:
+            resized = functional.interpolate(
+                nchw,
+                size=(output_height, output_width),
+                mode="bicubic",
+                align_corners=False,
+                antialias=True,
+            )
+        output = resized.permute(0, 2, 3, 1).clamp(0.0, 1.0)
+    report = {
+        "frames": int(value.shape[0]),
+        "input_width": width,
+        "input_height": height,
+        "output_width": output_width,
+        "output_height": output_height,
+        "input_pixels_per_frame": width * height,
+        "output_pixels_per_frame": output_width * output_height,
+        "visual_work_reduction": (
+            (width * height) / max(1, output_width * output_height)
+        ),
+        "resized": resized_image,
+        "multiple": multiple,
+        "quality": resize_quality,
+    }
+    if not resized_image:
+        return images, report
+    return (output[0] if single else output), report
+
+
+class VLMPerformanceProfile:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "profile": (
+                    tuple(PERFORMANCE_PROFILES),
+                    {"default": "Balanced"},
+                )
+            }
+        }
+
+    RETURN_TYPES = ("INT", "FLOAT", "INT", "INT", "BOOLEAN", "STRING")
+    RETURN_NAMES = (
+        "max_frames",
+        "max_megapixels",
+        "max_edge",
+        "batch_size",
+        "unload_after",
+        "profile_json",
+    )
+    FUNCTION = "profile"
+    CATEGORY = "VLM Nodes/Performance"
+    DESCRIPTION = (
+        "Portable speed/quality presets for the sampler, pixel optimizer, "
+        "and VLM batch inputs. The profile never changes global runtime state."
+    )
+
+    def profile(self, profile):
+        values = dict(PERFORMANCE_PROFILES[profile])
+        values["profile"] = profile
+        return (
+            values["max_frames"],
+            values["max_megapixels"],
+            values["max_edge"],
+            values["batch_size"],
+            values["unload_after"],
+            _json(values),
+        )
+
+
+class VLMImagePixelBudget:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "images": ("IMAGE",),
+                "max_megapixels": (
+                    "FLOAT",
+                    {"default": 1.0, "min": 0.01, "max": 64.0, "step": 0.05},
+                ),
+                "max_edge": (
+                    "INT",
+                    {"default": 1344, "min": 32, "max": 16384, "step": 14},
+                ),
+                "multiple": (
+                    ("1", "14", "28", "32"),
+                    {
+                        "default": "14",
+                        "tooltip": (
+                            "14/28 suit common VLM vision patches; 32 suits "
+                            "many detector backbones. Use 1 for arbitrary sizes."
+                        ),
+                    },
+                ),
+                "resize_quality": (
+                    RESIZE_QUALITY,
+                    {"default": "Fast (area)"},
+                ),
+            }
+        }
+
+    RETURN_TYPES = ("IMAGE", "INT", "INT", "STRING")
+    RETURN_NAMES = (
+        "optimized_images",
+        "width",
+        "height",
+        "optimization_report",
+    )
+    FUNCTION = "optimize"
+    CATEGORY = "VLM Nodes/Performance"
+    DESCRIPTION = (
+        "Apply one portable pixel budget before any VLM, avoiding repeated "
+        "high-resolution visual-token work while preserving aspect ratio."
+    )
+
+    def optimize(
+        self,
+        images,
+        max_megapixels,
+        max_edge,
+        multiple,
+        resize_quality,
+    ):
+        output, report = optimize_image_pixels(
+            images,
+            max_megapixels=float(max_megapixels),
+            max_edge=int(max_edge),
+            multiple=int(multiple),
+            resize_quality=resize_quality,
+        )
+        return (
+            output,
+            report["output_width"],
+            report["output_height"],
+            _json(report),
+        )
+
+
+NODE_CLASS_MAPPINGS = {
+    "VLMPerformanceProfile": VLMPerformanceProfile,
+    "VLMImagePixelBudget": VLMImagePixelBudget,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "VLMPerformanceProfile": "VLM Performance Profile",
+    "VLMImagePixelBudget": "VLM Image Pixel Budget",
+}

--- a/nodes/moondream31.py
+++ b/nodes/moondream31.py
@@ -1,0 +1,1636 @@
+"""Native Moondream 3/3.1 skills with isolated Photon inference.
+
+Moondream returns normalized boxes and points. The Moondream 3 Preview segment
+skill additionally returns a native SVG path. This module converts those
+results into the canonical spatial types shared by this pack and into ordinary
+ComfyUI IMAGE/MASK outputs. The final 3.1 model officially exposes query,
+caption, detect, and point; it is not falsely advertised as a segment model.
+
+The official ``moondream`` package intentionally runs in a dedicated virtual
+environment because its Pillow constraint conflicts with current ComfyUI
+releases.  The exact worker process is owned and terminated by the model
+handle, so ``unload_after`` reliably releases its GPU allocation.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import re
+import secrets
+import socket
+import subprocess
+import threading
+import time
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from io import BytesIO
+from multiprocessing.connection import Listener
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from PIL import Image, ImageChops, ImageDraw
+
+from .grounding import (
+    core_bounding_box_frames,
+    core_bounding_boxes,
+    detection_box_masks,
+)
+from .runtime import (
+    CachedModelNode,
+    model_cache_dir,
+    reserve_external_vram,
+    tensor_batch_to_pil,
+)
+from .vision_types import (
+    VLM_DETECTIONS,
+    VLM_POINTS,
+    Detection,
+    DetectionSequence,
+    FrameDetections,
+    PointSequence,
+    VisionPoint,
+)
+from .vision_utils import (
+    composite_with_mask,
+    masks_to_images,
+    render_detections,
+    sequence_masks,
+)
+
+LOGGER = logging.getLogger("ComfyUI_VLM_nodes")
+
+MOONDREAM31_MODEL = "MOONDREAM31_MODEL"
+MODEL_ID = "moondream3.1-9B-A2B"
+MODEL_SOURCE = "moondream/moondream3.1-9B-A2B"
+PREVIEW_MODEL_ID = "moondream3-preview"
+PREVIEW_MODEL_SOURCE = "moondream/moondream3-preview"
+MODEL_LICENSE_URL = "https://moondream.ai/licenses/model/1.0"
+RUNTIME_VERSION = "1.3.0"
+MAX_SVG_PATH_CHARS = 1_000_000
+MAX_SVG_POINTS = 250_000
+
+DEVICE_CHOICES = ("Auto", "NVIDIA CUDA", "Apple Silicon MPS")
+KV_CACHE_PROFILES = {
+    "Low VRAM (4K pages)": 4096,
+    "Balanced (8K pages)": 8192,
+    "Maximum throughput (16K pages)": 16384,
+    "Photon automatic": 0,
+}
+
+
+def _progress_text_sender(node_id: str | None) -> Callable[[str], None] | None:
+    if node_id is None:
+        return None
+    try:
+        from server import PromptServer
+
+        server = PromptServer.instance
+    except (ImportError, AttributeError):
+        return None
+
+    def send(text: str) -> None:
+        try:
+            server.send_progress_text(text, str(node_id), server.client_id)
+        except Exception as exc:  # noqa: BLE001 - UI enhancement only.
+            LOGGER.debug("Could not send Moondream progress text: %s", exc)
+
+    return send
+
+
+def _device_name(value: str) -> str:
+    if value == "NVIDIA CUDA":
+        return "cuda"
+    if value == "Apple Silicon MPS":
+        return "mps"
+    if value == "Auto":
+        # Photon performs the authoritative availability check in its isolated
+        # environment. Host OS is enough to choose the only supported options.
+        return "mps" if os.sys.platform == "darwin" else "cuda"
+    raise ValueError(f"Unsupported Moondream device {value!r}.")
+
+
+def _runtime_root() -> Path:
+    return model_cache_dir("moondream31-runtime")
+
+
+def _runtime_python(root: Path) -> Path:
+    override = os.environ.get("MOONDREAM_PYTHON", "").strip()
+    candidates = []
+    if override:
+        candidates.append(Path(override).expanduser())
+    candidates.extend(
+        (
+            root / ".venv" / "bin" / "python",
+            root / ".venv" / "Scripts" / "python.exe",
+            root / "venv" / "bin" / "python",
+            root / "venv" / "Scripts" / "python.exe",
+        )
+    )
+    for candidate in candidates:
+        if candidate.is_file():
+            # Do not resolve a POSIX venv's python symlink: executing the
+            # resolved base interpreter bypasses the venv's site-packages.
+            return candidate.absolute()
+    raise RuntimeError(
+        "Moondream 3.1 needs its isolated runtime. Create it on the same drive "
+        "as ComfyUI by following README.md → Moondream 3.1 isolated runtime. "
+        "You can instead set the server-side MOONDREAM_PYTHON environment "
+        "variable to an existing compatible runtime."
+    )
+
+
+def _free_loopback_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _image_bytes(image: Image.Image) -> bytes:
+    buffer = BytesIO()
+    image.convert("RGB").save(
+        buffer,
+        format="JPEG",
+        quality=95,
+        subsampling=0,
+        optimize=False,
+    )
+    return buffer.getvalue()
+
+
+def _worker_error(message: dict[str, Any]) -> RuntimeError:
+    detail = str(message.get("error") or "Unknown Moondream worker error")
+    trace = str(message.get("traceback") or "").strip()
+    if trace:
+        detail = f"{detail}\n\nIsolated worker traceback:\n{trace}"
+    return RuntimeError(detail)
+
+
+def _base_model_name(value: str) -> str:
+    return str(value).split("/", 1)[0]
+
+
+def _model_source(value: str) -> str:
+    return (
+        PREVIEW_MODEL_SOURCE
+        if _base_model_name(value) == PREVIEW_MODEL_ID
+        else MODEL_SOURCE
+    )
+
+
+def _safe_log_tail(path: Path | None, limit: int = 12_000) -> str:
+    if path is None or not path.is_file():
+        return ""
+    try:
+        with path.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            handle.seek(max(0, size - limit))
+            text = handle.read(limit).decode("utf-8", errors="replace")
+    except OSError:
+        return ""
+    # Worker logs should not contain credentials, but redact common secret
+    # assignments defensively before a tail is surfaced in ComfyUI.
+    return re.sub(
+        r"(?i)\b(api[_ -]?key|authorization|token)\b(\s*[:=]\s*)\S+",
+        r"\1\2<redacted>",
+        text,
+    ).strip()
+
+
+def _worker_environment(
+    cache: Path,
+    auth_key: bytes,
+    model_name: str,
+) -> dict[str, str]:
+    """Build a minimal inherited environment without unrelated credentials."""
+
+    blocked_names = {
+        "ALL_PROXY",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+    }
+    secret_name = re.compile(
+        r"(?:API[_-]?KEY|AUTHORIZATION|CREDENTIAL|PASSWORD|SECRET|TOKEN)",
+        re.IGNORECASE,
+    )
+    environment = {
+        name: value
+        for name, value in os.environ.items()
+        if name.upper() not in blocked_names and not secret_name.search(name)
+    }
+    # These are the only upstream credentials the worker can legitimately use.
+    # They remain server-side environment values and never become node inputs.
+    hf_token = os.environ.get("HF_TOKEN", "").strip()
+    if hf_token:
+        environment["HF_TOKEN"] = hf_token
+    moondream_key = os.environ.get("MOONDREAM_API_KEY", "").strip()
+    if "/" in model_name and moondream_key:
+        environment["MOONDREAM_API_KEY"] = moondream_key
+    environment["HF_HOME"] = str(cache / "huggingface")
+    environment["HF_HUB_DISABLE_TELEMETRY"] = "1"
+    environment["DO_NOT_TRACK"] = "1"
+    environment["MOONDREAM_WORKER_AUTH"] = auth_key.hex()
+    return environment
+
+
+@dataclass(frozen=True)
+class Moondream31Config:
+    model: str
+    device: str
+    max_batch_size: int
+    kv_cache_pages: int
+
+
+class Moondream31Model:
+    """Restartable owner for one exact isolated Photon process."""
+
+    def __init__(self, config: Moondream31Config):
+        self.config = config
+        self.root = _runtime_root()
+        self.python = _runtime_python(self.root)
+        self.cache = self.root / "cache"
+        self.logs = self.root / "logs"
+        self.cache.mkdir(parents=True, exist_ok=True)
+        self.logs.mkdir(parents=True, exist_ok=True)
+        self._connection = None
+        self._process: subprocess.Popen | None = None
+        self._listener = None
+        self._log_handle = None
+        self._request_id = 0
+        self._lock = threading.RLock()
+        self._log_path: Path | None = None
+        self.runtime_info: dict[str, Any] = {}
+
+    @property
+    def is_running(self) -> bool:
+        return self._process is not None and self._process.poll() is None
+
+    def _close_transport(self) -> None:
+        connection, listener = self._connection, self._listener
+        self._connection = None
+        self._listener = None
+        for value in (connection, listener):
+            if value is not None:
+                try:
+                    value.close()
+                except Exception as exc:  # noqa: BLE001 - heterogeneous handles.
+                    LOGGER.debug("Could not close Moondream transport: %s", exc)
+        if self._log_handle is not None:
+            try:
+                self._log_handle.close()
+            except Exception as exc:  # noqa: BLE001 - interpreter shutdown.
+                LOGGER.debug("Could not close Moondream log handle: %s", exc)
+            self._log_handle = None
+
+    def _unexpected_exit(self, operation: str) -> RuntimeError:
+        process = self._process
+        code = None
+        if process is not None:
+            code = process.poll()
+            if code is None:
+                try:
+                    code = process.wait(timeout=1)
+                except subprocess.TimeoutExpired:
+                    pass
+        log_path = self._log_path
+        self.close()
+        tail = _safe_log_tail(log_path)
+        detail = (
+            f"Moondream Photon worker stopped during {operation} (code {code})."
+        )
+        if "cudaLibraryLoadData" in tail:
+            detail += (
+                " The installed Photon CUDA kernel requires a newer compatible "
+                "NVIDIA driver/runtime combination than this machine exposes."
+            )
+        if tail:
+            detail += f"\n\nSanitized worker log tail:\n{tail}"
+        elif log_path is not None:
+            detail += f" See {log_path}."
+        return RuntimeError(detail)
+
+    def ensure_started(
+        self,
+        progress: Callable[[str], None] | None = None,
+    ) -> None:
+        with self._lock:
+            if self.is_running and self._connection is not None:
+                return
+            self.close()
+            if progress is not None:
+                progress("Preparing isolated Moondream 3.1 runtime…")
+
+            # The model repository is about 10.5 GB. This is intentionally an
+            # estimate rather than a promise; Photon sizes its KV cache from
+            # the selected profile and performs the final device check.
+            reserve_external_vram(18 * 1024**3)
+            host = "127.0.0.1"
+            port = _free_loopback_port()
+            auth_key = secrets.token_bytes(32)
+            listener = Listener((host, port), authkey=auth_key)
+            try:
+                listener._listener._socket.settimeout(30)  # type: ignore[attr-defined]
+            except (AttributeError, OSError):
+                # Timeout is a guard for CPython's current Listener internals;
+                # the worker connects before importing any heavy dependency.
+                pass
+            self._listener = listener
+
+            worker = Path(__file__).with_name("moondream31_worker.py").resolve()
+            log_path = self.logs / (
+                f"worker-{time.strftime('%Y%m%d-%H%M%S')}-{os.getpid()}.log"
+            )
+            self._log_path = log_path
+            self._log_handle = log_path.open("ab", buffering=0)
+            command = [
+                str(self.python),
+                str(worker),
+                "--host",
+                host,
+                "--port",
+                str(port),
+                "--model",
+                self.config.model,
+                "--device",
+                self.config.device,
+                "--max-batch-size",
+                str(self.config.max_batch_size),
+                "--kv-cache-pages",
+                str(self.config.kv_cache_pages),
+            ]
+            # Keep unrelated provider keys out of the sidecar and keep the
+            # IPC authentication secret out of process listings.
+            environment = _worker_environment(
+                self.cache,
+                auth_key,
+                self.config.model,
+            )
+            startup_info = None
+            creation_flags = 0
+            if os.name == "nt":
+                startup_info = subprocess.STARTUPINFO()
+                startup_info.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+                creation_flags = subprocess.CREATE_NO_WINDOW
+            try:
+                self._process = subprocess.Popen(
+                    command,
+                    cwd=str(self.root),
+                    env=environment,
+                    stdin=subprocess.DEVNULL,
+                    stdout=self._log_handle,
+                    stderr=subprocess.STDOUT,
+                    startupinfo=startup_info,
+                    creationflags=creation_flags,
+                    close_fds=os.name != "nt",
+                )
+                self._connection = listener.accept()
+            except Exception:
+                self.close()
+                raise
+
+            deadline = time.monotonic() + 3600
+            loading_announced = False
+            while time.monotonic() < deadline:
+                if self._process.poll() is not None:
+                    raise self._unexpected_exit("startup")
+                if not self._connection.poll(0.25):
+                    if progress is not None and not loading_announced:
+                        progress(
+                            "Loading Moondream 3.1 weights on the GPU "
+                            "(the first run downloads them to D)…"
+                        )
+                        loading_announced = True
+                    continue
+                try:
+                    message = self._connection.recv()
+                except (EOFError, OSError) as exc:
+                    raise self._unexpected_exit("startup") from exc
+                status = message.get("status")
+                if message.get("type") == "fatal":
+                    error = _worker_error(message)
+                    self.close()
+                    raise error
+                if message.get("type") == "status" and status == "ready":
+                    self.runtime_info = dict(message)
+                    self.runtime_info.update(
+                        {
+                            "model": self.config.model,
+                            "device": self.config.device,
+                            "max_batch_size": self.config.max_batch_size,
+                            "kv_cache_pages": self.config.kv_cache_pages,
+                            "python": str(self.python),
+                            "cache": str(self.cache),
+                            "log": str(log_path),
+                        }
+                    )
+                    if progress is not None:
+                        progress("Moondream 3.1 ready.")
+                    return
+            self.close()
+            raise TimeoutError(
+                f"Moondream 3.1 did not finish loading within one hour. See {log_path}."
+            )
+
+    def request(
+        self,
+        operation: str,
+        *,
+        progress: Callable[[str], None] | None = None,
+        **payload: Any,
+    ) -> dict[str, Any]:
+        with self._lock:
+            self.ensure_started(progress)
+            self._request_id += 1
+            request_id = self._request_id
+            self._connection.send({"id": request_id, "operation": operation, **payload})
+            streamed = ""
+            while True:
+                if self._process is None or self._process.poll() is not None:
+                    raise self._unexpected_exit(operation)
+                if not self._connection.poll(0.25):
+                    continue
+                try:
+                    message = self._connection.recv()
+                except (EOFError, OSError) as exc:
+                    raise self._unexpected_exit(operation) from exc
+                if message.get("id") != request_id:
+                    continue
+                message_type = message.get("type")
+                if message_type == "chunk":
+                    streamed += str(message.get("text") or "")
+                    if progress is not None:
+                        progress(streamed)
+                    continue
+                if message_type == "error":
+                    raise _worker_error(message)
+                if message_type == "result":
+                    return dict(message.get("result") or {})
+
+    def close(self) -> None:
+        with self._lock:
+            process = self._process
+            connection = self._connection
+            if (
+                process is not None
+                and process.poll() is None
+                and connection is not None
+            ):
+                try:
+                    self._request_id += 1
+                    connection.send({"id": self._request_id, "operation": "shutdown"})
+                    if connection.poll(5):
+                        connection.recv()
+                except (BrokenPipeError, EOFError, OSError):
+                    pass
+            if process is not None and process.poll() is None:
+                try:
+                    process.wait(timeout=25)
+                except subprocess.TimeoutExpired:
+                    process.terminate()
+                    try:
+                        process.wait(timeout=10)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        process.wait(timeout=10)
+            self._process = None
+            self._close_transport()
+
+    unload = close
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:  # noqa: BLE001,S110 - destructors must not raise.
+            pass
+
+
+def _normalized_number(value: Any, name: str) -> float:
+    number = float(value)
+    if not math.isfinite(number) or not 0.0 <= number <= 1.0:
+        raise ValueError(f"{name} must be finite and normalized to [0, 1].")
+    return number
+
+
+def _normalized_bbox(value: Any) -> tuple[float, float, float, float]:
+    if not isinstance(value, dict):
+        raise TypeError("Moondream bbox must be an object.")
+    x1 = _normalized_number(value.get("x_min"), "bbox x_min")
+    y1 = _normalized_number(value.get("y_min"), "bbox y_min")
+    x2 = _normalized_number(value.get("x_max"), "bbox x_max")
+    y2 = _normalized_number(value.get("y_max"), "bbox y_max")
+    if x2 <= x1 or y2 <= y1:
+        raise ValueError("Moondream bbox must have positive width and height.")
+    return x1, y1, x2, y2
+
+
+def _pixel_bbox(
+    value: Any,
+    width: int,
+    height: int,
+) -> tuple[float, float, float, float]:
+    x1, y1, x2, y2 = _normalized_bbox(value)
+    return x1 * width, y1 * height, x2 * width, y2 * height
+
+
+def _curve_contours(
+    svg_path: str,
+    bbox: tuple[float, float, float, float],
+    width: int,
+    height: int,
+    precision_px: float,
+) -> list[list[tuple[float, float]]]:
+    if not isinstance(svg_path, str) or not svg_path.strip():
+        raise ValueError("Moondream returned an empty SVG path.")
+    if len(svg_path) > MAX_SVG_PATH_CHARS:
+        raise ValueError("Moondream SVG path is larger than the safety limit.")
+    try:
+        from svgelements import Close, Move
+        from svgelements import Path as SVGPath
+    except Exception as exc:
+        raise RuntimeError(
+            "SVG mask conversion needs `svgelements>=1.9.6,<2`. "
+            "Reinstall this node pack's base requirements."
+        ) from exc
+
+    try:
+        path = SVGPath(svg_path)
+    except Exception as exc:
+        raise ValueError(f"Moondream returned an invalid SVG path: {exc}") from exc
+    if not path:
+        raise ValueError("Moondream returned an empty SVG path.")
+
+    x1, y1, x2, y2 = bbox
+    box_width = x2 - x1
+    box_height = y2 - y1
+    contours: list[list[tuple[float, float]]] = []
+    current: list[tuple[float, float]] = []
+    point_count = 0
+
+    def transform(point: Any) -> tuple[float, float]:
+        nonlocal point_count
+        px = float(point.real)
+        py = float(point.imag)
+        if not math.isfinite(px) or not math.isfinite(py):
+            raise ValueError("SVG path contains non-finite coordinates.")
+        # Native Moondream path coordinates are normalized within its bbox.
+        output = (
+            min(float(width), max(0.0, (x1 + px * box_width) * width)),
+            min(float(height), max(0.0, (y1 + py * box_height) * height)),
+        )
+        point_count += 1
+        if point_count > MAX_SVG_POINTS:
+            raise ValueError("SVG path exceeds the flattened point safety limit.")
+        return output
+
+    def finish() -> None:
+        nonlocal current
+        clean = []
+        for point in current:
+            if not clean or point != clean[-1]:
+                clean.append(point)
+        if len(clean) >= 3:
+            if clean[0] == clean[-1]:
+                clean.pop()
+            if len(clean) >= 3:
+                contours.append(clean)
+        current = []
+
+    for segment in path:
+        if isinstance(segment, Move):
+            finish()
+            if segment.end is not None:
+                current = [transform(segment.end)]
+            continue
+        if not current and segment.start is not None:
+            current = [transform(segment.start)]
+        if isinstance(segment, Close):
+            finish()
+            continue
+        try:
+            normalized_length = float(segment.length(error=1e-5))
+        except TypeError:
+            normalized_length = float(segment.length())
+        if not math.isfinite(normalized_length):
+            raise ValueError("SVG path contains a non-finite curve length.")
+        pixel_length = normalized_length * max(
+            box_width * width,
+            box_height * height,
+        )
+        samples = min(
+            2048,
+            max(1, math.ceil(pixel_length / float(precision_px))),
+        )
+        for index in range(1, samples + 1):
+            current.append(transform(segment.point(index / samples)))
+    finish()
+    if not contours:
+        raise ValueError("SVG path did not contain a fillable closed shape.")
+    return contours
+
+
+def svg_path_to_mask(
+    svg_path: str,
+    bbox: Any,
+    width: int,
+    height: int,
+    *,
+    supersample: int = 4,
+    precision_px: float = 1.0,
+) -> tuple[
+    torch.Tensor, tuple[tuple[float, float], ...], list[list[tuple[float, float]]]
+]:
+    """Rasterize a native Moondream SVG path into an antialiased Comfy mask.
+
+    SVG subpaths use an even-odd fill, preserving ordinary holes and disjoint
+    islands without requiring a system SVG library.
+    """
+
+    if not isinstance(width, int) or width <= 0:
+        raise ValueError("width must be a positive integer.")
+    if not isinstance(height, int) or height <= 0:
+        raise ValueError("height must be a positive integer.")
+    if not isinstance(supersample, int) or not 1 <= supersample <= 8:
+        raise ValueError("supersample must be between 1 and 8.")
+    if not math.isfinite(precision_px) or precision_px <= 0:
+        raise ValueError("precision_px must be finite and positive.")
+    normalized_box = _normalized_bbox(bbox)
+    contours = _curve_contours(
+        svg_path,
+        normalized_box,
+        width,
+        height,
+        precision_px,
+    )
+
+    canvas_size = (width * supersample, height * supersample)
+    combined = Image.new("1", canvas_size, 0)
+    for contour in contours:
+        layer = Image.new("1", canvas_size, 0)
+        points = [
+            (
+                round(x * supersample),
+                round(y * supersample),
+            )
+            for x, y in contour
+        ]
+        ImageDraw.Draw(layer).polygon(points, fill=1)
+        combined = ImageChops.logical_xor(combined, layer)
+    high_resolution = combined.convert("L").point(lambda value: 255 if value else 0)
+    if supersample > 1:
+        high_resolution = high_resolution.resize(
+            (width, height),
+            Image.Resampling.LANCZOS,
+        )
+    array = np.asarray(high_resolution, dtype=np.float32) / 255.0
+    mask = torch.from_numpy(array.copy()).clamp(0, 1)
+    primary = max(contours, key=lambda value: abs(_polygon_area(value)))
+    return mask, tuple(primary), contours
+
+
+def _polygon_area(points: Iterable[tuple[float, float]]) -> float:
+    values = list(points)
+    return 0.5 * sum(
+        x1 * y2 - x2 * y1 for (x1, y1), (x2, y2) in zip(values, values[1:] + values[:1])
+    )
+
+
+def _sampled_images(
+    image: torch.Tensor,
+    frame_stride: int,
+) -> tuple[list[Image.Image], list[int], int, int]:
+    if not isinstance(frame_stride, int) or frame_stride < 1:
+        raise ValueError("frame_stride must be a positive integer.")
+    images = tensor_batch_to_pil(image)
+    if not images:
+        raise ValueError("At least one image/frame is required.")
+    dimensions = {item.size for item in images}
+    if len(dimensions) != 1:
+        raise ValueError("Every image in a batch must have the same dimensions.")
+    indices = list(range(0, len(images), frame_stride))
+    width, height = images[0].size
+    return [images[index] for index in indices], indices, width, height
+
+
+def _performance(
+    *,
+    result: dict[str, Any],
+    total_elapsed: float,
+    source_frames: int,
+    processed_frames: int,
+    source_fps: float,
+    frame_stride: int,
+) -> dict[str, Any]:
+    worker_elapsed = max(float(result.get("elapsed_seconds", 0.0)), 1e-9)
+    total_elapsed = max(float(total_elapsed), 1e-9)
+    target_processed_fps = source_fps / frame_stride
+    sustained_fps = processed_frames / total_elapsed
+    return {
+        "source_frames": source_frames,
+        "processed_frames": processed_frames,
+        "skipped_frames": source_frames - processed_frames,
+        "source_fps": source_fps,
+        "frame_stride": frame_stride,
+        "target_processed_fps": target_processed_fps,
+        "worker_seconds": worker_elapsed,
+        "end_to_end_seconds": total_elapsed,
+        "worker_fps": processed_frames / worker_elapsed,
+        "sustained_fps": sustained_fps,
+        "realtime_factor": sustained_fps / target_processed_fps,
+        "parallel_requests": int(result.get("parallel_requests", 1)),
+        "warm_runtime": True,
+    }
+
+
+def _frames_to_payload(images: list[Image.Image]) -> list[bytes]:
+    return [_image_bytes(image) for image in images]
+
+
+def _validate_fps(value: float) -> float:
+    fps = float(value)
+    if not math.isfinite(fps) or fps <= 0:
+        raise ValueError("fps must be finite and positive.")
+    return fps
+
+
+def _detect_sequence(
+    items: list[dict[str, Any]],
+    *,
+    selected_indices: list[int],
+    source_frames: int,
+    width: int,
+    height: int,
+    object_prompt: str,
+    fps: float,
+    max_objects: int,
+    metadata: dict[str, Any],
+    source: str,
+) -> DetectionSequence:
+    frames = []
+    for frame_index, item in zip(selected_indices, items):
+        timestamp = frame_index / fps
+        detections = []
+        objects = item.get("objects", [])
+        if not isinstance(objects, list):
+            raise TypeError("Moondream detect result must contain an object list.")
+        for record in objects[:max_objects]:
+            detections.append(
+                Detection(
+                    bbox_xyxy=_pixel_bbox(record, width, height),
+                    label=object_prompt,
+                    frame_index=frame_index,
+                    timestamp=timestamp,
+                    source=source,
+                    metadata={"native_bbox": record},
+                )
+            )
+        frames.append(
+            FrameDetections(
+                frame_index=frame_index,
+                timestamp=timestamp,
+                width=width,
+                height=height,
+                detections=tuple(detections),
+            )
+        )
+    return DetectionSequence(
+        width=width,
+        height=height,
+        frames=tuple(frames),
+        frame_count=source_frames,
+        fps=fps,
+        source=source,
+        metadata={
+            "skill": "detect",
+            "object": object_prompt,
+            "performance": metadata,
+        },
+    )
+
+
+def _point_sequence(
+    items: list[dict[str, Any]],
+    *,
+    selected_indices: list[int],
+    source_frames: int,
+    width: int,
+    height: int,
+    object_prompt: str,
+    fps: float,
+    max_points: int,
+    metadata: dict[str, Any],
+    source: str,
+) -> PointSequence:
+    points = []
+    for frame_index, item in zip(selected_indices, items):
+        timestamp = frame_index / fps
+        records = item.get("points", [])
+        if not isinstance(records, list):
+            raise TypeError("Moondream point result must contain a point list.")
+        for record in records[:max_points]:
+            if not isinstance(record, dict):
+                raise TypeError("Moondream points must be objects.")
+            x = _normalized_number(record.get("x"), "point x") * width
+            y = _normalized_number(record.get("y"), "point y") * height
+            points.append(
+                VisionPoint(
+                    x=x,
+                    y=y,
+                    label=object_prompt,
+                    frame_index=frame_index,
+                    timestamp=timestamp,
+                    source=source,
+                    metadata={"native_point": record},
+                )
+            )
+    return PointSequence(
+        width=width,
+        height=height,
+        points=tuple(points),
+        frame_count=source_frames,
+        fps=fps,
+        source=source,
+        metadata={
+            "skill": "point",
+            "object": object_prompt,
+            "performance": metadata,
+        },
+    )
+
+
+def _render_points(image: torch.Tensor, points: PointSequence) -> torch.Tensor:
+    output = []
+    by_frame: dict[int, list[VisionPoint]] = {}
+    for point in points.points:
+        by_frame.setdefault(point.frame_index, []).append(point)
+    for frame_index, frame in enumerate(tensor_batch_to_pil(image)):
+        canvas = frame.copy()
+        draw = ImageDraw.Draw(canvas)
+        radius = max(4, round(min(canvas.size) / 100))
+        width = max(2, round(radius / 3))
+        for point in by_frame.get(frame_index, []):
+            x, y = point.x, point.y
+            draw.ellipse(
+                (x - radius, y - radius, x + radius, y + radius),
+                outline=(0, 255, 128),
+                width=width,
+            )
+            draw.line((x - radius, y, x + radius, y), fill=(0, 255, 128), width=width)
+            draw.line((x, y - radius, x, y + radius), fill=(0, 255, 128), width=width)
+        array = np.asarray(canvas, dtype=np.float32) / 255.0
+        output.append(torch.from_numpy(array.copy()))
+    return torch.stack(output)
+
+
+def _spatial_refs(
+    value: str,
+    width: int,
+    height: int,
+    points: PointSequence | None,
+    detections: DetectionSequence | None,
+) -> list[list[float]]:
+    refs: list[list[float]] = []
+    text = str(value or "").strip()
+    if text:
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid spatial_refs_json: {exc.msg}.") from exc
+        if not isinstance(parsed, list):
+            raise ValueError("spatial_refs_json must be a JSON array.")
+        refs.extend(parsed)
+    if points is not None:
+        if not isinstance(points, PointSequence):
+            raise TypeError("points must be a VLM point sequence.")
+        refs.extend([[point.x / width, point.y / height] for point in points.points])
+    if detections is not None:
+        if not isinstance(detections, DetectionSequence):
+            raise TypeError("detections must be a VLM detection sequence.")
+        for detection in detections.all_detections():
+            x1, y1, x2, y2 = detection.bbox_xyxy
+            refs.append([x1 / width, y1 / height, x2 / width, y2 / height])
+    if len(refs) > 64:
+        raise ValueError("At most 64 spatial references are accepted.")
+    normalized = []
+    for index, ref in enumerate(refs):
+        if not isinstance(ref, (list, tuple)) or len(ref) not in (2, 4):
+            raise ValueError(
+                f"Spatial reference {index} must contain 2 point values or 4 bbox values."
+            )
+        values = [
+            _normalized_number(component, f"spatial reference {index}")
+            for component in ref
+        ]
+        if len(values) == 4 and (values[2] <= values[0] or values[3] <= values[1]):
+            raise ValueError(f"Spatial bbox reference {index} has no positive area.")
+        normalized.append(values)
+    return normalized
+
+
+class Moondream31Loader(CachedModelNode):
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "license_accepted": (
+                    "BOOLEAN",
+                    {
+                        "default": False,
+                        "tooltip": (
+                            "Required acknowledgement of Moondream Model License "
+                            f"1.0: {MODEL_LICENSE_URL}"
+                        ),
+                    },
+                ),
+                "device": (DEVICE_CHOICES, {"default": "Auto"}),
+                "max_batch_size": (
+                    "INT",
+                    {
+                        "default": 4,
+                        "min": 1,
+                        "max": 32,
+                        "tooltip": (
+                            "Maximum concurrent Photon requests. 4 is a strong "
+                            "starting point for video detection."
+                        ),
+                    },
+                ),
+                "kv_cache_profile": (
+                    tuple(KV_CACHE_PROFILES),
+                    {"default": "Balanced (8K pages)"},
+                ),
+            },
+            "optional": {
+                "model_or_adapter": (
+                    "STRING",
+                    {
+                        "default": MODEL_ID,
+                        "tooltip": (
+                            "Use moondream3.1-9B-A2B for query/caption/detect/"
+                            "point, or moondream3-preview for SVG segment. "
+                            "Adapters may use the upstream base/adapter syntax."
+                        ),
+                    },
+                ),
+            },
+        }
+
+    RETURN_TYPES = (MOONDREAM31_MODEL, "STRING")
+    RETURN_NAMES = ("model", "runtime_info")
+    FUNCTION = "load"
+    CATEGORY = "VLM Nodes/Moondream 3"
+    DESCRIPTION = (
+        "Load official Moondream 3/3.1 Photon in a conflict-free sidecar. "
+        "The model cache, worker environment, and logs stay under ComfyUI models."
+    )
+
+    def load(
+        self,
+        license_accepted,
+        device,
+        max_batch_size,
+        kv_cache_profile,
+        model_or_adapter=MODEL_ID,
+    ):
+        if not license_accepted:
+            raise ValueError(
+                "Moondream Model License 1.0 acceptance is required before "
+                f"loading. Read {MODEL_LICENSE_URL}"
+            )
+        model_name = str(model_or_adapter).strip()
+        if not model_name or any(character in model_name for character in "\r\n\0"):
+            raise ValueError("model_or_adapter must be one non-empty line.")
+        config = Moondream31Config(
+            model=model_name,
+            device=_device_name(device),
+            max_batch_size=int(max_batch_size),
+            kv_cache_pages=KV_CACHE_PROFILES[kv_cache_profile],
+        )
+        model = self.get_or_create_model(config, lambda: Moondream31Model(config))
+        model.ensure_started()
+        return model, json.dumps(
+            model.runtime_info,
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            indent=2,
+        )
+
+
+class Moondream31Query:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "model": (MOONDREAM31_MODEL,),
+                "question": (
+                    "STRING",
+                    {"multiline": True, "default": "Describe this image precisely."},
+                ),
+                "max_tokens": (
+                    "INT",
+                    {"default": 512, "min": 1, "max": 8192},
+                ),
+                "reasoning": ("BOOLEAN", {"default": False}),
+                "stream_output": ("BOOLEAN", {"default": True}),
+                "unload_after": ("BOOLEAN", {"default": False}),
+            },
+            "optional": {
+                "image": ("IMAGE",),
+                "image_index": (
+                    "INT",
+                    {"default": 0, "min": 0, "max": 1_000_000},
+                ),
+            },
+            "hidden": {"unique_id": "UNIQUE_ID"},
+        }
+
+    RETURN_TYPES = ("STRING", "STRING", "STRING")
+    RETURN_NAMES = ("answer", "reasoning_json", "performance_json")
+    FUNCTION = "query"
+    CATEGORY = "VLM Nodes/Moondream 3"
+
+    def query(
+        self,
+        model,
+        question,
+        max_tokens,
+        reasoning,
+        stream_output,
+        unload_after,
+        image=None,
+        image_index=0,
+        unique_id=None,
+    ):
+        if not isinstance(model, Moondream31Model):
+            raise TypeError("model must come from Moondream 3.1 Loader.")
+        prompt = str(question).strip()
+        if not prompt:
+            raise ValueError("question cannot be empty.")
+        payload = None
+        if image is not None:
+            images = tensor_batch_to_pil(image)
+            index = int(image_index)
+            if not 0 <= index < len(images):
+                raise IndexError("image_index is outside the input batch.")
+            payload = _image_bytes(images[index])
+        progress = _progress_text_sender(unique_id) if bool(stream_output) else None
+        started = time.perf_counter()
+        try:
+            result = model.request(
+                "query",
+                progress=progress,
+                image=payload,
+                question=prompt,
+                max_tokens=int(max_tokens),
+                reasoning=bool(reasoning),
+                stream=bool(stream_output),
+            )
+            performance = {
+                "worker_seconds": result.get("elapsed_seconds"),
+                "end_to_end_seconds": time.perf_counter() - started,
+                "warm_runtime": True,
+            }
+            return (
+                str(result.get("answer") or ""),
+                json.dumps(
+                    result.get("reasoning"),
+                    ensure_ascii=False,
+                    allow_nan=False,
+                    sort_keys=True,
+                    indent=2,
+                ),
+                json.dumps(performance, allow_nan=False, sort_keys=True, indent=2),
+            )
+        finally:
+            if unload_after:
+                model.close()
+
+
+class Moondream31Caption:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "model": (MOONDREAM31_MODEL,),
+                "image": ("IMAGE",),
+                "length": (("short", "normal", "long"), {"default": "normal"}),
+                "max_tokens": (
+                    "INT",
+                    {"default": 512, "min": 1, "max": 8192},
+                ),
+                "stream_output": ("BOOLEAN", {"default": True}),
+                "unload_after": ("BOOLEAN", {"default": False}),
+                "image_index": (
+                    "INT",
+                    {"default": 0, "min": 0, "max": 1_000_000},
+                ),
+            },
+            "hidden": {"unique_id": "UNIQUE_ID"},
+        }
+
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("caption", "performance_json")
+    FUNCTION = "caption"
+    CATEGORY = "VLM Nodes/Moondream 3"
+
+    def caption(
+        self,
+        model,
+        image,
+        length,
+        max_tokens,
+        stream_output,
+        unload_after,
+        image_index,
+        unique_id=None,
+    ):
+        if not isinstance(model, Moondream31Model):
+            raise TypeError("model must come from Moondream 3.1 Loader.")
+        images = tensor_batch_to_pil(image)
+        index = int(image_index)
+        if not 0 <= index < len(images):
+            raise IndexError("image_index is outside the input batch.")
+        progress = _progress_text_sender(unique_id) if bool(stream_output) else None
+        started = time.perf_counter()
+        try:
+            result = model.request(
+                "caption",
+                progress=progress,
+                image=_image_bytes(images[index]),
+                length=length,
+                max_tokens=int(max_tokens),
+                stream=bool(stream_output),
+            )
+            performance = {
+                "worker_seconds": result.get("elapsed_seconds"),
+                "end_to_end_seconds": time.perf_counter() - started,
+                "warm_runtime": True,
+            }
+            return str(result.get("caption") or ""), json.dumps(
+                performance,
+                allow_nan=False,
+                sort_keys=True,
+                indent=2,
+            )
+        finally:
+            if unload_after:
+                model.close()
+
+
+class Moondream31Detect:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "model": (MOONDREAM31_MODEL,),
+                "image": ("IMAGE",),
+                "object": (
+                    "STRING",
+                    {"multiline": False, "default": "person"},
+                ),
+                "fps": (
+                    "FLOAT",
+                    {"default": 30.0, "min": 0.001, "max": 1000.0, "step": 0.001},
+                ),
+                "frame_stride": (
+                    "INT",
+                    {
+                        "default": 1,
+                        "min": 1,
+                        "max": 100_000,
+                        "tooltip": "1 analyzes every frame; 2 analyzes every other frame.",
+                    },
+                ),
+                "parallel_requests": (
+                    "INT",
+                    {
+                        "default": 4,
+                        "min": 1,
+                        "max": 32,
+                        "tooltip": (
+                            "Concurrent frame requests let Photon form dynamic GPU batches."
+                        ),
+                    },
+                ),
+                "max_objects": (
+                    "INT",
+                    {"default": 100, "min": 1, "max": 1000},
+                ),
+                "unload_after": ("BOOLEAN", {"default": False}),
+            }
+        }
+
+    RETURN_TYPES = (
+        VLM_DETECTIONS,
+        "STRING",
+        "IMAGE",
+        "MASK",
+        "BOUNDING_BOX",
+        "BOUNDING_BOXES",
+        "STRING",
+    )
+    RETURN_NAMES = (
+        "detections",
+        "detections_json",
+        "preview",
+        "box_masks",
+        "bounding_boxes",
+        "bounding_boxes_with_metadata",
+        "performance_json",
+    )
+    FUNCTION = "detect"
+    CATEGORY = "VLM Nodes/Moondream 3"
+    DESCRIPTION = (
+        "Warm, dynamically batched Moondream detection for images or video "
+        "frame batches. Reports measured worker and end-to-end FPS."
+    )
+
+    def detect(
+        self,
+        model,
+        image,
+        object,
+        fps,
+        frame_stride,
+        parallel_requests,
+        max_objects,
+        unload_after,
+    ):
+        if not isinstance(model, Moondream31Model):
+            raise TypeError("model must come from Moondream 3.1 Loader.")
+        object_prompt = str(object).strip()
+        if not object_prompt:
+            raise ValueError("object cannot be empty.")
+        fps_value = _validate_fps(fps)
+        sampled, indices, width, height = _sampled_images(image, int(frame_stride))
+        started = time.perf_counter()
+        try:
+            result = model.request(
+                "detect",
+                images=_frames_to_payload(sampled),
+                object=object_prompt,
+                parallel_requests=int(parallel_requests),
+                max_tokens=64,
+            )
+            performance = _performance(
+                result=result,
+                total_elapsed=time.perf_counter() - started,
+                source_frames=len(tensor_batch_to_pil(image)),
+                processed_frames=len(indices),
+                source_fps=fps_value,
+                frame_stride=int(frame_stride),
+            )
+            items = result.get("items", [])
+            if not isinstance(items, list) or len(items) != len(indices):
+                raise RuntimeError("Moondream returned an incomplete detect batch.")
+            sequence = _detect_sequence(
+                items,
+                selected_indices=indices,
+                source_frames=int(image.shape[0]) if image.ndim == 4 else 1,
+                width=width,
+                height=height,
+                object_prompt=object_prompt,
+                fps=fps_value,
+                max_objects=int(max_objects),
+                metadata=performance,
+                source=_model_source(model.config.model),
+            )
+            return (
+                sequence,
+                sequence.to_json(indent=2),
+                render_detections(image, sequence),
+                detection_box_masks(sequence),
+                core_bounding_box_frames(sequence),
+                core_bounding_boxes(sequence),
+                json.dumps(performance, allow_nan=False, sort_keys=True, indent=2),
+            )
+        finally:
+            if unload_after:
+                model.close()
+
+
+class Moondream31Point:
+    @classmethod
+    def INPUT_TYPES(cls):
+        inputs = Moondream31Detect.INPUT_TYPES()
+        required = dict(inputs["required"])
+        required["object"] = (
+            "STRING",
+            {"multiline": False, "default": "person"},
+        )
+        required["max_points"] = required.pop("max_objects")
+        return {"required": required}
+
+    RETURN_TYPES = (VLM_POINTS, "STRING", "IMAGE", "STRING")
+    RETURN_NAMES = ("points", "points_json", "preview", "performance_json")
+    FUNCTION = "point"
+    CATEGORY = "VLM Nodes/Moondream 3"
+
+    def point(
+        self,
+        model,
+        image,
+        object,
+        fps,
+        frame_stride,
+        parallel_requests,
+        max_points,
+        unload_after,
+    ):
+        if not isinstance(model, Moondream31Model):
+            raise TypeError("model must come from Moondream 3.1 Loader.")
+        object_prompt = str(object).strip()
+        if not object_prompt:
+            raise ValueError("object cannot be empty.")
+        fps_value = _validate_fps(fps)
+        sampled, indices, width, height = _sampled_images(image, int(frame_stride))
+        started = time.perf_counter()
+        try:
+            result = model.request(
+                "point",
+                images=_frames_to_payload(sampled),
+                object=object_prompt,
+                parallel_requests=int(parallel_requests),
+                max_tokens=64,
+            )
+            performance = _performance(
+                result=result,
+                total_elapsed=time.perf_counter() - started,
+                source_frames=int(image.shape[0]) if image.ndim == 4 else 1,
+                processed_frames=len(indices),
+                source_fps=fps_value,
+                frame_stride=int(frame_stride),
+            )
+            items = result.get("items", [])
+            if not isinstance(items, list) or len(items) != len(indices):
+                raise RuntimeError("Moondream returned an incomplete point batch.")
+            sequence = _point_sequence(
+                items,
+                selected_indices=indices,
+                source_frames=int(image.shape[0]) if image.ndim == 4 else 1,
+                width=width,
+                height=height,
+                object_prompt=object_prompt,
+                fps=fps_value,
+                max_points=int(max_points),
+                metadata=performance,
+                source=_model_source(model.config.model),
+            )
+            return (
+                sequence,
+                sequence.to_json(indent=2),
+                _render_points(image, sequence),
+                json.dumps(performance, allow_nan=False, sort_keys=True, indent=2),
+            )
+        finally:
+            if unload_after:
+                model.close()
+
+
+class Moondream31Segment:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "model": (MOONDREAM31_MODEL,),
+                "image": ("IMAGE",),
+                "object": (
+                    "STRING",
+                    {"multiline": False, "default": "foreground object"},
+                ),
+                "fps": (
+                    "FLOAT",
+                    {"default": 30.0, "min": 0.001, "max": 1000.0, "step": 0.001},
+                ),
+                "frame_stride": (
+                    "INT",
+                    {"default": 1, "min": 1, "max": 100_000},
+                ),
+                "parallel_requests": (
+                    "INT",
+                    {"default": 2, "min": 1, "max": 32},
+                ),
+                "svg_supersample": (
+                    "INT",
+                    {
+                        "default": 4,
+                        "min": 1,
+                        "max": 8,
+                        "tooltip": "Higher values produce smoother mask edges.",
+                    },
+                ),
+                "unload_after": ("BOOLEAN", {"default": False}),
+            },
+            "optional": {
+                "spatial_refs_json": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "[]",
+                        "tooltip": (
+                            "Normalized [x,y] points and/or [x1,y1,x2,y2] boxes."
+                        ),
+                    },
+                ),
+                "points": (VLM_POINTS,),
+                "detections": (VLM_DETECTIONS,),
+            },
+        }
+
+    RETURN_TYPES = (
+        VLM_DETECTIONS,
+        "STRING",
+        "STRING",
+        "MASK",
+        "IMAGE",
+        "IMAGE",
+        "IMAGE",
+        "BOUNDING_BOX",
+        "BOUNDING_BOXES",
+        "STRING",
+    )
+    RETURN_NAMES = (
+        "segments",
+        "segments_json",
+        "native_svg_paths",
+        "combined_masks",
+        "black_white_masks",
+        "cutouts",
+        "overlays",
+        "bounding_boxes",
+        "bounding_boxes_with_metadata",
+        "performance_json",
+    )
+    FUNCTION = "segment"
+    CATEGORY = "VLM Nodes/Moondream 3"
+    DESCRIPTION = (
+        "Preserve Moondream's native SVG geometry and convert it into "
+        "antialiased masks, polygons, cutouts, overlays, and core boxes."
+    )
+
+    def segment(
+        self,
+        model,
+        image,
+        object,
+        fps,
+        frame_stride,
+        parallel_requests,
+        svg_supersample,
+        unload_after,
+        spatial_refs_json="[]",
+        points=None,
+        detections=None,
+    ):
+        if not isinstance(model, Moondream31Model):
+            raise TypeError("model must come from Moondream 3.1 Loader.")
+        if _base_model_name(model.config.model) != PREVIEW_MODEL_ID:
+            raise ValueError(
+                "SVG segment is a Moondream 3 Preview skill. The official "
+                "Moondream 3.1 model exposes query, caption, detect, and point "
+                "but does not list segment. Load model_or_adapter="
+                "'moondream3-preview' for this node."
+            )
+        object_prompt = str(object).strip()
+        if not object_prompt:
+            raise ValueError("object cannot be empty.")
+        fps_value = _validate_fps(fps)
+        sampled, indices, width, height = _sampled_images(image, int(frame_stride))
+        refs = _spatial_refs(
+            spatial_refs_json,
+            width,
+            height,
+            points,
+            detections,
+        )
+        started = time.perf_counter()
+        try:
+            result = model.request(
+                "segment",
+                images=_frames_to_payload(sampled),
+                object=object_prompt,
+                spatial_refs=refs,
+                parallel_requests=int(parallel_requests),
+                max_tokens=2048,
+            )
+            performance = _performance(
+                result=result,
+                total_elapsed=time.perf_counter() - started,
+                source_frames=int(image.shape[0]) if image.ndim == 4 else 1,
+                processed_frames=len(indices),
+                source_fps=fps_value,
+                frame_stride=int(frame_stride),
+            )
+            items = result.get("items", [])
+            if not isinstance(items, list) or len(items) != len(indices):
+                raise RuntimeError("Moondream returned an incomplete segment batch.")
+
+            frames = []
+            paths = []
+            for frame_index, item in zip(indices, items):
+                if not isinstance(item, dict):
+                    raise TypeError("Moondream segment items must be objects.")
+                path = str(item.get("path") or "")
+                native_bbox = item.get(
+                    "bbox",
+                    {"x_min": 0.0, "y_min": 0.0, "x_max": 1.0, "y_max": 1.0},
+                )
+                mask, polygon, contours = svg_path_to_mask(
+                    path,
+                    native_bbox,
+                    width,
+                    height,
+                    supersample=int(svg_supersample),
+                )
+                timestamp = frame_index / fps_value
+                detection = Detection(
+                    bbox_xyxy=_pixel_bbox(native_bbox, width, height),
+                    label=object_prompt,
+                    polygon=polygon,
+                    mask=mask,
+                    frame_index=frame_index,
+                    timestamp=timestamp,
+                    source=_model_source(model.config.model),
+                    metadata={
+                        "native_bbox": native_bbox,
+                        "native_svg_path": path,
+                        "svg_subpaths": len(contours),
+                        "svg_fill_rule": "evenodd",
+                    },
+                )
+                frames.append(
+                    FrameDetections(
+                        frame_index=frame_index,
+                        timestamp=timestamp,
+                        width=width,
+                        height=height,
+                        detections=(detection,),
+                    )
+                )
+                paths.append(
+                    {
+                        "frame_index": frame_index,
+                        "bbox": native_bbox,
+                        "path": path,
+                    }
+                )
+            sequence = DetectionSequence(
+                width=width,
+                height=height,
+                frames=tuple(frames),
+                frame_count=int(image.shape[0]) if image.ndim == 4 else 1,
+                fps=fps_value,
+                source=_model_source(model.config.model),
+                metadata={
+                    "skill": "segment",
+                    "object": object_prompt,
+                    "spatial_refs": refs,
+                    "performance": performance,
+                },
+            )
+            masks, _individual, _mapping = sequence_masks(sequence)
+            _composite, cutouts, _background, _mask_preview = composite_with_mask(
+                image,
+                masks,
+                background_color="#000000",
+            )
+            return (
+                sequence,
+                sequence.to_json(indent=2),
+                json.dumps(paths, ensure_ascii=False, allow_nan=False, indent=2),
+                masks,
+                masks_to_images(masks),
+                cutouts,
+                render_detections(image, sequence),
+                core_bounding_box_frames(sequence),
+                core_bounding_boxes(sequence),
+                json.dumps(performance, allow_nan=False, sort_keys=True, indent=2),
+            )
+        finally:
+            if unload_after:
+                model.close()
+
+
+NODE_CLASS_MAPPINGS = {
+    "Moondream31Loader": Moondream31Loader,
+    "Moondream31Query": Moondream31Query,
+    "Moondream31Caption": Moondream31Caption,
+    "Moondream31Detect": Moondream31Detect,
+    "Moondream31Point": Moondream31Point,
+    "Moondream31Segment": Moondream31Segment,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "Moondream31Loader": "Moondream 3 / 3.1 Loader (Isolated Photon)",
+    "Moondream31Query": "Moondream 3 / 3.1 Query",
+    "Moondream31Caption": "Moondream 3 / 3.1 Caption",
+    "Moondream31Detect": "Moondream 3 / 3.1 Detect (Image / Video)",
+    "Moondream31Point": "Moondream 3 / 3.1 Point (Image / Video)",
+    "Moondream31Segment": "Moondream 3 Preview SVG Segment (Image / Video)",
+}

--- a/nodes/moondream31_worker.py
+++ b/nodes/moondream31_worker.py
@@ -1,0 +1,354 @@
+"""Isolated Moondream 3.1 Photon worker.
+
+This file is launched directly by the ComfyUI process with the dedicated
+Moondream virtual environment.  It intentionally has no imports from ComfyUI
+or this package: Moondream pins a Pillow version that is incompatible with
+current ComfyUI releases, so sharing one Python environment is unsafe.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import sys
+import time
+import traceback
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+from importlib.metadata import PackageNotFoundError, version
+from io import BytesIO
+from multiprocessing.connection import Client
+from typing import Any
+
+from PIL import Image
+
+
+def _register_moondream31_if_needed(model_name: str) -> bool:
+    """Bridge the official model-card ID on runtimes released before the ID.
+
+    Moondream 3.1 uses the same MD3 Photon runtime/checkpoint format as the
+    preview. Stable moondream 1.3.0 / kestrel 0.4.2 shipped the safetensors
+    loader but omitted the new registry entry published by the later model
+    card. Prefer an upstream entry whenever present; otherwise clone only the
+    runtime metadata and point it at the official 3.1 weights.
+    """
+
+    if model_name != "moondream3.1-9B-A2B":
+        return False
+    from kestrel.models import get_spec, register
+
+    try:
+        get_spec(model_name)
+        return False
+    except ValueError:
+        preview = get_spec("moondream3-preview")
+        register(
+            replace(
+                preview,
+                name=model_name,
+                repo_id="moondream/moondream3.1-9B-A2B",
+                filename="model.safetensors",
+                checkpoint_format="md3",
+            )
+        )
+        return True
+
+
+def _base_model_name(value: str) -> str:
+    return str(value).split("/", 1)[0]
+
+
+def _model_skills(model_name: str) -> frozenset[str]:
+    base_model = _base_model_name(model_name)
+    if base_model == "moondream3.1-9B-A2B":
+        # Source of truth: the final 3.1 model card. Segment remains a skill
+        # of the 3 Preview and cloud API, not the final local 3.1 checkpoint.
+        return frozenset(("caption", "query", "detect", "point"))
+    from kestrel.models import get_spec
+
+    spec = get_spec(base_model)
+    templates = spec.default_config.get("tokenizer", {}).get("templates", {})
+    return frozenset(
+        name for name, template in templates.items() if template is not None
+    )
+
+
+def _image(value: bytes) -> Image.Image:
+    if not isinstance(value, bytes):
+        raise TypeError("Worker image payloads must be bytes.")
+    with Image.open(BytesIO(value)) as source:
+        return source.convert("RGB")
+
+
+def _parallel(
+    images: list[bytes],
+    operation: Callable[[Image.Image], dict[str, Any]],
+    workers: int,
+) -> list[dict[str, Any]]:
+    if not images:
+        return []
+    worker_count = max(1, min(int(workers), len(images)))
+    with ThreadPoolExecutor(max_workers=worker_count) as pool:
+        return list(pool.map(lambda value: operation(_image(value)), images))
+
+
+def _private_shutdown(model: Any) -> None:
+    """Best-effort graceful Photon shutdown before the process exits.
+
+    The public moondream package currently has no close method.  Process
+    isolation remains the hard guarantee: the parent terminates this exact
+    process if this best-effort private cleanup ever changes or stalls.
+    """
+
+    engine = getattr(model, "_engine", None)
+    loop = getattr(model, "_loop", None)
+    thread = getattr(model, "_thread", None)
+    if engine is not None and loop is not None:
+        try:
+            import asyncio
+
+            asyncio.run_coroutine_threadsafe(engine.shutdown(), loop).result(timeout=20)
+        except Exception:  # noqa: BLE001,S110 - private best-effort cleanup.
+            pass
+        try:
+            loop.call_soon_threadsafe(loop.stop)
+        except Exception:  # noqa: BLE001,S110 - private best-effort cleanup.
+            pass
+    if thread is not None:
+        try:
+            thread.join(timeout=5)
+        except Exception:  # noqa: BLE001,S110 - private best-effort cleanup.
+            pass
+
+
+def _request(
+    model: Any,
+    request: dict[str, Any],
+    send: Callable[[dict[str, Any]], None],
+    max_batch_size: int,
+    supported_skills: frozenset[str],
+) -> bool:
+    request_id = request.get("id")
+    operation = request.get("operation")
+    if operation == "shutdown":
+        send({"id": request_id, "type": "result", "result": {"closed": True}})
+        return False
+    if operation not in supported_skills:
+        raise ValueError(
+            f"Model does not support the {operation!r} skill. "
+            f"Available skills: {', '.join(sorted(supported_skills))}."
+        )
+
+    started = time.perf_counter()
+    settings = {"max_tokens": int(request.get("max_tokens", 512))}
+    if operation in {"query", "caption"}:
+        image_payload = request.get("image")
+        image = _image(image_payload) if image_payload is not None else None
+        if operation == "query":
+            output = model.query(
+                image=image,
+                question=str(request["question"]),
+                stream=bool(request.get("stream", True)),
+                settings=settings,
+                reasoning=bool(request.get("reasoning", False)),
+            )
+            key = "answer"
+        else:
+            if image is None:
+                raise ValueError("Caption requires an image.")
+            output = model.caption(
+                image=image,
+                length=str(request.get("length", "normal")),
+                stream=bool(request.get("stream", True)),
+                settings=settings,
+            )
+            key = "caption"
+
+        value = output[key]
+        if isinstance(value, str):
+            text = value
+        else:
+            chunks = []
+            for chunk in value:
+                chunk_text = str(chunk)
+                chunks.append(chunk_text)
+                send(
+                    {
+                        "id": request_id,
+                        "type": "chunk",
+                        "text": chunk_text,
+                    }
+                )
+            text = "".join(chunks)
+        result = {
+            key: text,
+            "elapsed_seconds": time.perf_counter() - started,
+        }
+        if operation == "query" and output.get("reasoning") is not None:
+            result["reasoning"] = output["reasoning"]
+        send({"id": request_id, "type": "result", "result": result})
+        return True
+
+    images = request.get("images")
+    if not isinstance(images, list):
+        raise TypeError(f"{operation} requires an image list.")
+    workers = min(
+        max_batch_size,
+        max(1, int(request.get("parallel_requests", max_batch_size))),
+    )
+    object_prompt = str(request.get("object", "")).strip()
+    if not object_prompt:
+        raise ValueError(f"{operation} requires a non-empty object prompt.")
+
+    if operation == "detect":
+        results = _parallel(
+            images,
+            lambda image: model.detect(image, object_prompt, settings=settings),
+            workers,
+        )
+    elif operation == "point":
+        results = _parallel(
+            images,
+            lambda image: model.point(image, object_prompt, settings=settings),
+            workers,
+        )
+    elif operation == "segment":
+        spatial_refs = request.get("spatial_refs") or None
+        results = _parallel(
+            images,
+            lambda image: model.segment(
+                image,
+                object_prompt,
+                spatial_refs=spatial_refs,
+                stream=False,
+                settings=settings,
+            ),
+            workers,
+        )
+    else:
+        raise ValueError(f"Unknown worker operation {operation!r}.")
+
+    send(
+        {
+            "id": request_id,
+            "type": "result",
+            "result": {
+                "items": results,
+                "processed_frames": len(images),
+                "parallel_requests": workers,
+                "elapsed_seconds": time.perf_counter() - started,
+            },
+        }
+    )
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--auth-key")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--device", required=True)
+    parser.add_argument("--max-batch-size", type=int, required=True)
+    parser.add_argument("--kv-cache-pages", type=int, default=0)
+    args = parser.parse_args()
+
+    auth_key = args.auth_key or os.environ.pop("MOONDREAM_WORKER_AUTH", "")
+    if not auth_key:
+        parser.error("worker authentication is missing")
+    connection = Client(
+        (args.host, args.port),
+        authkey=bytes.fromhex(auth_key),
+    )
+
+    def send(value: dict[str, Any]) -> None:
+        connection.send(value)
+
+    send(
+        {
+            "type": "status",
+            "status": "loading",
+            "python": sys.version.split()[0],
+            "platform": platform.platform(),
+            "pid": os.getpid(),
+        }
+    )
+
+    model = None
+    try:
+        import moondream as md
+
+        base_model = _base_model_name(args.model)
+        compatibility_registration = _register_moondream31_if_needed(base_model)
+        supported_skills = _model_skills(args.model)
+        kwargs: dict[str, Any] = {
+            "local": True,
+            "model": args.model,
+            "device": args.device,
+            "max_batch_size": args.max_batch_size,
+        }
+        if args.kv_cache_pages > 0:
+            kwargs["kv_cache_pages"] = args.kv_cache_pages
+        model = md.vl(**kwargs)
+        try:
+            package_version = version("moondream")
+        except PackageNotFoundError:
+            package_version = "unknown"
+        send(
+            {
+                "type": "status",
+                "status": "ready",
+                "moondream_version": package_version,
+                "compatibility_registration": compatibility_registration,
+                "skills": sorted(supported_skills),
+                "pid": os.getpid(),
+            }
+        )
+
+        running = True
+        while running:
+            request = connection.recv()
+            request_id = request.get("id") if isinstance(request, dict) else None
+            try:
+                if not isinstance(request, dict):
+                    raise TypeError("Worker requests must be dictionaries.")
+                running = _request(
+                    model,
+                    request,
+                    send,
+                    args.max_batch_size,
+                    supported_skills,
+                )
+            except Exception as exc:  # noqa: BLE001 - report request failures over IPC.
+                send(
+                    {
+                        "id": request_id,
+                        "type": "error",
+                        "error": f"{type(exc).__name__}: {exc}",
+                        "traceback": traceback.format_exc(limit=12),
+                    }
+                )
+    except Exception as exc:  # noqa: BLE001 - report startup failures over IPC.
+        send(
+            {
+                "type": "fatal",
+                "error": f"{type(exc).__name__}: {exc}",
+                "traceback": traceback.format_exc(limit=20),
+            }
+        )
+        return 1
+    finally:
+        if model is not None:
+            _private_shutdown(model)
+        try:
+            connection.close()
+        except OSError:
+            pass
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/nodes/runtime.py
+++ b/nodes/runtime.py
@@ -31,6 +31,7 @@ from PIL import Image
 
 LOGGER = logging.getLogger("ComfyUI_VLM_nodes")
 GGUF_EXTENSIONS = {".gguf"}
+PIL_CONVERSION_CHUNK_BYTES = 128 * 1024**2
 LLAMA_FLASH_ATTENTION_CHOICES = ("Auto", "Enabled", "Disabled")
 LLAMA_SPLIT_MODE_CHOICES = ("Layer", "Row", "Single GPU")
 LLAMA_VISION_HANDLER_CHOICES = (
@@ -157,39 +158,67 @@ def hf_download(repo_id: str, filename: str, subdirectory: str, **kwargs: Any) -
     return Path(hub.hf_hub_download(**download_kwargs))
 
 
+def _tensor_image_batch_to_uint8(images: torch.Tensor) -> np.ndarray:
+    """Convert HWC/CHW/BHWC/BCHW image data in one vectorized transfer.
+
+    Video nodes previously moved and normalized every frame independently.
+    Converting a bounded batch at once reduces Python dispatch and host-device
+    transfer overhead while preserving the same clipping contract. The caller
+    chunks long videos to cap peak temporary memory. The returned array is
+    always contiguous BHWC RGB uint8.
+    """
+
+    if not isinstance(images, torch.Tensor):
+        raise TypeError(f"Expected a torch.Tensor, got {type(images).__name__}.")
+    value = images.detach()
+    if value.ndim == 2:
+        value = value.unsqueeze(-1)
+    if value.ndim == 3:
+        value = value.unsqueeze(0)
+    if value.ndim != 4:
+        raise ValueError(
+            f"Expected an HWC/BHWC or CHW/BCHW image tensor, got {tuple(value.shape)}."
+        )
+
+    # ComfyUI uses BHWC. BCHW is accepted for compatibility with older nodes.
+    if value.shape[-1] not in (1, 3, 4) and value.shape[1] in (1, 3, 4):
+        value = value.permute(0, 2, 3, 1)
+    if value.shape[-1] not in (1, 3, 4):
+        raise ValueError(f"Unsupported image channel shape: {tuple(value.shape)}.")
+
+    value = torch.nan_to_num(
+        value.to(device="cpu", dtype=torch.float32),
+        nan=0.0,
+        posinf=1.0,
+        neginf=0.0,
+    )
+    if value.numel():
+        flat = value.reshape(value.shape[0], -1)
+        needs_byte_scale = (
+            (flat.amax(dim=1) > 1.0) | (flat.amin(dim=1) < 0.0)
+        ).view(-1, 1, 1, 1)
+        value = torch.where(needs_byte_scale, value / 255.0, value)
+    value = value.clamp(0.0, 1.0).mul(255.0).round().to(torch.uint8)
+    if value.shape[-1] == 1:
+        value = value.expand(*value.shape[:-1], 3)
+    elif value.shape[-1] == 4:
+        value = value[..., :3]
+    return np.ascontiguousarray(value.numpy())
+
+
 def tensor_to_pil(image: torch.Tensor, index: int = 0) -> Image.Image:
     """Convert a Comfy IMAGE tensor to an RGB PIL image without torchvision."""
 
     if not isinstance(image, torch.Tensor):
         raise TypeError(f"Expected a torch.Tensor, got {type(image).__name__}.")
-    value = image.detach()
+    value = image
     if value.ndim == 4:
         if not 0 <= index < value.shape[0]:
             raise IndexError(f"Image batch index {index} is out of range.")
         value = value[index]
-    if value.ndim == 2:
-        value = value.unsqueeze(-1)
-    if value.ndim != 3:
-        raise ValueError(
-            f"Expected an HWC/BHWC or CHW/BCHW image tensor, got {tuple(value.shape)}."
-        )
-
-    # ComfyUI uses HWC. CHW is accepted for compatibility with older callers.
-    if value.shape[-1] not in (1, 3, 4) and value.shape[0] in (1, 3, 4):
-        value = value.permute(1, 2, 0)
-    if value.shape[-1] not in (1, 3, 4):
-        raise ValueError(f"Unsupported image channel shape: {tuple(value.shape)}.")
-
-    value = torch.nan_to_num(
-        value.to(device="cpu", dtype=torch.float32), nan=0.0, posinf=1.0, neginf=0.0
-    )
-    if value.numel() and (value.max() > 1.0 or value.min() < 0.0):
-        value = value / 255.0
-    array = value.clamp(0.0, 1.0).mul(255.0).round().to(torch.uint8).numpy()
-    if array.shape[-1] == 1:
-        array = np.repeat(array, 3, axis=-1)
-    elif array.shape[-1] == 4:
-        array = array[..., :3]
+    elif index != 0:
+        raise IndexError("A single image only has batch index 0.")
+    array = _tensor_image_batch_to_uint8(value)[0]
     return Image.fromarray(array, mode="RGB")
 
 
@@ -198,7 +227,24 @@ def tensor_batch_to_pil(images: torch.Tensor) -> list[Image.Image]:
         return [tensor_to_pil(images)]
     if images.ndim != 4:
         raise ValueError(f"Expected an IMAGE batch, got {tuple(images.shape)}.")
-    return [tensor_to_pil(images, index) for index in range(images.shape[0])]
+    if images.shape[0] == 0:
+        return []
+    if images.device.type == "cpu":
+        # Per-frame conversion benchmarks faster for ordinary CPU-resident
+        # Comfy IMAGE batches and keeps the transient working set tiny.
+        return [tensor_to_pil(images, index) for index in range(images.shape[0])]
+    # Convert several frames per tensor operation without creating an
+    # unbounded full-video float32 temporary. On accelerator-resident batches,
+    # this amortizes device synchronization and transfers across many frames.
+    # The 128 MiB working-set ceiling keeps long HD/4K videos reliable.
+    frame_elements = max(1, int(images[0].numel()))
+    working_bytes = frame_elements * max(4, images.element_size())
+    chunk_frames = max(1, PIL_CONVERSION_CHUNK_BYTES // working_bytes)
+    output: list[Image.Image] = []
+    for start in range(0, int(images.shape[0]), chunk_frames):
+        frames = _tensor_image_batch_to_uint8(images[start : start + chunk_frames])
+        output.extend(Image.fromarray(frame, mode="RGB") for frame in frames)
+    return output
 
 
 def pil_to_tensor(image: Image.Image) -> torch.Tensor:
@@ -540,18 +586,21 @@ class CachedModelNode:
     def __init__(self) -> None:
         self._model_handle = None
         self._model_key = None
+        self._model_lock = threading.RLock()
 
     def get_or_create_model(self, key: Any, factory: Callable[[], Any]):
-        if self._model_handle is None or self._model_key != key:
-            close_handle(self._model_handle)
-            self._model_handle = factory()
-            self._model_key = key
-        return self._model_handle
+        with self._model_lock:
+            if self._model_handle is None or self._model_key != key:
+                close_handle(self._model_handle)
+                self._model_handle = factory()
+                self._model_key = key
+            return self._model_handle
 
     def clear_model(self) -> None:
-        close_handle(self._model_handle)
-        self._model_handle = None
-        self._model_key = None
+        with self._model_lock:
+            close_handle(self._model_handle)
+            self._model_handle = None
+            self._model_key = None
 
     def maybe_clear_model(self, unload_after: bool) -> None:
         if unload_after:

--- a/nodes/video_intelligence.py
+++ b/nodes/video_intelligence.py
@@ -132,13 +132,13 @@ def _visual_signals(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Return normalized per-frame motion and coarse scene-change scores."""
 
-    rgb = (
-        frames[..., :3]
-        .detach()
-        .to(dtype=torch.float32)
-        .movedim(-1, 1)
-        .clamp(0, 1)
-    )
+    # Downsample before clamping or moving to CPU. Comfy IMAGE tensors are
+    # normally float32 already, so this avoids a second full-resolution video
+    # allocation merely to compute small scene/motion thumbnails.
+    rgb = frames[..., :3].detach()
+    if rgb.dtype != torch.float32:
+        rgb = rgb.to(dtype=torch.float32)
+    rgb = rgb.movedim(-1, 1)
     side = min(int(thumbnail_size), int(frames.shape[1]), int(frames.shape[2]))
     thumbnails = F.interpolate(
         rgb,
@@ -146,7 +146,7 @@ def _visual_signals(
         mode="bilinear",
         align_corners=False,
         antialias=True,
-    )
+    ).clamp(0, 1)
     gray = (
         thumbnails[:, 0] * 0.299
         + thumbnails[:, 1] * 0.587

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "comfyui_vlm_nodes"
-version = "3.2.0"
+version = "3.3.0"
 description = "Production-ready local and API vision-language nodes for ComfyUI"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -21,6 +21,7 @@ dependencies = [
   "scipy>=1.10,<2",
   "soundfile>=0.12",
   "symusic>=0.5",
+  "svgelements>=1.9.6,<2",
   "transformers>=5.4,<6",
 ]
 classifiers = [

--- a/requirements-moondream31.txt
+++ b/requirements-moondream31.txt
@@ -1,0 +1,7 @@
+# Install this file only into the isolated Moondream sidecar environment.
+# Do not install it into ComfyUI's main environment: moondream 1.3 pins
+# Pillow <11 while current ComfyUI uses a newer Pillow release.
+moondream==1.3.0
+# moondream 1.3.0 expects this exact runtime API. 0.4.7+ renamed the
+# prefix-mask kernel and is not source-compatible with kestrel 0.4.2.
+kestrel-kernels==0.4.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,5 @@ safetensors>=0.4.3
 scipy>=1.10,<2
 soundfile>=0.12
 symusic>=0.5
+svgelements>=1.9.6,<2
 transformers>=5.4,<6

--- a/tests/test_acceleration.py
+++ b/tests/test_acceleration.py
@@ -1,0 +1,111 @@
+import json
+import threading
+import time
+
+import pytest
+import torch
+from ComfyUI_VLM_nodes.nodes.acceleration import (
+    VLMImagePixelBudget,
+    VLMPerformanceProfile,
+    optimize_image_pixels,
+)
+from ComfyUI_VLM_nodes.nodes.runtime import (
+    CachedModelNode,
+    tensor_batch_to_pil,
+    tensor_to_pil,
+)
+
+
+def test_batch_conversion_matches_single_frame_contract():
+    images = torch.tensor(
+        [
+            [
+                [[float("nan"), 0.5, 2.0], [-1.0, 0.25, 1.0]],
+                [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]],
+            ],
+            [
+                [[255.0, 128.0, 0.0], [0.0, 64.0, 255.0]],
+                [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+            ],
+        ]
+    )
+    batch = tensor_batch_to_pil(images)
+    assert len(batch) == 2
+    for index, converted in enumerate(batch):
+        assert converted.mode == "RGB"
+        assert converted.size == (2, 2)
+        assert converted.tobytes() == tensor_to_pil(images, index).tobytes()
+
+    with pytest.raises(IndexError, match="only has batch index 0"):
+        tensor_to_pil(images[0], 1)
+
+
+def test_pixel_budget_preserves_aspect_and_patch_multiple():
+    images = torch.rand((3, 1080, 1920, 3), dtype=torch.float32)
+    output, report = optimize_image_pixels(
+        images,
+        max_megapixels=0.5,
+        max_edge=1024,
+        multiple=14,
+        resize_quality="Fast (area)",
+    )
+    assert output.ndim == 4
+    assert output.shape[0] == 3
+    assert output.shape[1] % 14 == 0
+    assert output.shape[2] % 14 == 0
+    assert output.shape[1] * output.shape[2] <= 500_000
+    assert output.shape[2] <= 1024
+    assert report["visual_work_reduction"] > 4
+    assert output.shape[2] / output.shape[1] == pytest.approx(16 / 9, rel=0.03)
+
+
+def test_pixel_budget_never_upscales():
+    image = torch.rand((240, 320, 3), dtype=torch.float32)
+    output, report = optimize_image_pixels(
+        image,
+        max_megapixels=2.0,
+        max_edge=2048,
+        multiple=1,
+        resize_quality="Quality (bicubic)",
+    )
+    assert output is image
+    assert report["resized"] is False
+
+
+def test_performance_nodes_return_standard_comfy_values():
+    profile = VLMPerformanceProfile().profile("Live / robotics")
+    assert profile[:5] == (24, 0.5, 896, 8, False)
+    assert json.loads(profile[5])["profile"] == "Live / robotics"
+
+    optimized = VLMImagePixelBudget().optimize(
+        torch.rand((1, 1000, 1600, 3)),
+        0.5,
+        1024,
+        "14",
+        "Fast (area)",
+    )
+    assert optimized[1] % 14 == 0
+    assert optimized[2] % 14 == 0
+
+
+def test_cached_model_node_prevents_duplicate_concurrent_loads():
+    node = CachedModelNode()
+    factory_calls = []
+    handles = []
+
+    def factory():
+        factory_calls.append(1)
+        time.sleep(0.02)
+        return object()
+
+    def load():
+        handles.append(node.get_or_create_model("same-model", factory))
+
+    threads = [threading.Thread(target=load) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(factory_calls) == 1
+    assert len({id(handle) for handle in handles}) == 1

--- a/tests/test_moondream31.py
+++ b/tests/test_moondream31.py
@@ -1,0 +1,327 @@
+import importlib
+import inspect
+import json
+import sys
+import types
+from dataclasses import dataclass
+
+import pytest
+import torch
+
+PACKAGE = __package__.split(".")[0] if __package__ else "ComfyUI_VLM_nodes"
+module = importlib.import_module(f"{PACKAGE}.nodes.moondream31")
+worker = importlib.import_module(f"{PACKAGE}.nodes.moondream31_worker")
+
+Moondream31Detect = module.Moondream31Detect
+Moondream31Loader = module.Moondream31Loader
+Moondream31Model = module.Moondream31Model
+Moondream31Segment = module.Moondream31Segment
+svg_path_to_mask = module.svg_path_to_mask
+
+
+def _fake_model(handler, model_name=module.MODEL_ID):
+    model = object.__new__(Moondream31Model)
+    model.config = module.Moondream31Config(
+        model=model_name,
+        device="cuda",
+        max_batch_size=4,
+        kv_cache_pages=8192,
+    )
+    model.request = handler
+    model.close = lambda: None
+    return model
+
+
+def test_svg_path_is_transformed_from_bbox_space_to_image_pixels():
+    mask, polygon, contours = svg_path_to_mask(
+        "M 0 0 H 1 V 1 H 0 Z",
+        {"x_min": 0.25, "y_min": 0.25, "x_max": 0.75, "y_max": 0.75},
+        100,
+        80,
+        supersample=4,
+    )
+    assert mask.shape == (80, 100)
+    assert mask[40, 50] > 0.99
+    assert mask[5, 5] == 0
+    assert mask.sum().item() == pytest.approx(2000, rel=0.06)
+    assert len(polygon) >= 4
+    assert len(contours) == 1
+    xs = [point[0] for point in polygon]
+    ys = [point[1] for point in polygon]
+    assert min(xs) == pytest.approx(25)
+    assert max(xs) == pytest.approx(75)
+    assert min(ys) == pytest.approx(20)
+    assert max(ys) == pytest.approx(60)
+
+
+def test_svg_curves_and_evenodd_holes_are_preserved():
+    path = "M 0 0 H 1 V 1 H 0 Z M .25 .25 C .4 .1 .6 .1 .75 .25 V .75 H .25 Z"
+    mask, polygon, contours = svg_path_to_mask(
+        path,
+        {"x_min": 0, "y_min": 0, "x_max": 1, "y_max": 1},
+        128,
+        128,
+        supersample=4,
+        precision_px=0.5,
+    )
+    assert len(contours) == 2
+    assert len(polygon) >= 4
+    assert mask[8, 8] > 0.99
+    assert mask[64, 64] < 0.01
+
+
+@pytest.mark.parametrize(
+    ("path", "bbox", "message"),
+    [
+        ("", {"x_min": 0, "y_min": 0, "x_max": 1, "y_max": 1}, "empty"),
+        (
+            "M 0 0 L nan 1 Z",
+            {"x_min": 0, "y_min": 0, "x_max": 1, "y_max": 1},
+            "invalid",
+        ),
+        (
+            "M 0 0 H 1 V 1 Z",
+            {"x_min": 0.7, "y_min": 0, "x_max": 0.2, "y_max": 1},
+            "positive",
+        ),
+    ],
+)
+def test_svg_rejects_malformed_or_unsafe_geometry(path, bbox, message):
+    with pytest.raises((TypeError, ValueError), match=message):
+        svg_path_to_mask(path, bbox, 64, 64)
+
+
+def test_video_detect_uses_stride_parallelism_and_reports_measured_fps():
+    observed = {}
+
+    def request(operation, **payload):
+        observed["operation"] = operation
+        observed.update(payload)
+        return {
+            "items": [
+                {
+                    "objects": [
+                        {
+                            "x_min": 0.1,
+                            "y_min": 0.2,
+                            "x_max": 0.4,
+                            "y_max": 0.6,
+                        }
+                    ]
+                },
+                {"objects": []},
+            ],
+            "elapsed_seconds": 0.1,
+            "parallel_requests": 2,
+        }
+
+    images = torch.zeros((4, 48, 64, 3), dtype=torch.float32)
+    outputs = Moondream31Detect().detect(
+        _fake_model(request),
+        images,
+        "person",
+        30.0,
+        2,
+        2,
+        20,
+        False,
+    )
+    sequence = outputs[0]
+    performance = json.loads(outputs[-1])
+    assert observed["operation"] == "detect"
+    assert len(observed["images"]) == 2
+    assert observed["parallel_requests"] == 2
+    assert sequence.frame_count == 4
+    assert [frame.frame_index for frame in sequence.frames] == [0, 2]
+    assert sequence.frames[0].detections[0].bbox_xyxy == pytest.approx(
+        (6.4, 9.6, 25.6, 28.8)
+    )
+    assert outputs[2].shape == images.shape
+    assert outputs[3].shape == (4, 48, 64)
+    assert performance["processed_frames"] == 2
+    assert performance["worker_fps"] == pytest.approx(20)
+    assert performance["target_processed_fps"] == pytest.approx(15)
+    assert performance["parallel_requests"] == 2
+
+
+def test_segment_exposes_svg_mask_cutout_overlay_and_structured_detection():
+    def request(operation, **payload):
+        assert operation == "segment"
+        assert payload["spatial_refs"] == [[0.5, 0.5]]
+        return {
+            "items": [
+                {
+                    "path": "M 0 0 H 1 V 1 H 0 Z",
+                    "bbox": {
+                        "x_min": 0.25,
+                        "y_min": 0.25,
+                        "x_max": 0.75,
+                        "y_max": 0.75,
+                    },
+                }
+            ],
+            "elapsed_seconds": 0.2,
+            "parallel_requests": 1,
+        }
+
+    image = torch.ones((1, 32, 40, 3), dtype=torch.float32)
+    outputs = Moondream31Segment().segment(
+        _fake_model(request, module.PREVIEW_MODEL_ID),
+        image,
+        "object",
+        1.0,
+        1,
+        1,
+        4,
+        False,
+        spatial_refs_json="[[0.5, 0.5]]",
+    )
+    sequence = outputs[0]
+    native = json.loads(outputs[2])
+    mask = outputs[3]
+    mask_image = outputs[4]
+    cutout = outputs[5]
+    overlay = outputs[6]
+    detection = sequence.frames[0].detections[0]
+    assert native[0]["path"].startswith("M 0 0")
+    assert mask.shape == (1, 32, 40)
+    assert mask_image.shape == (1, 32, 40, 3)
+    assert cutout.shape == image.shape
+    assert overlay.shape == image.shape
+    assert mask[0, 16, 20] > 0.99
+    assert mask[0, 2, 2] == 0
+    assert cutout[0, 16, 20].min() > 0.99
+    assert cutout[0, 2, 2].max() == 0
+    assert detection.mask is not None
+    assert detection.polygon is not None
+    assert detection.metadata["native_svg_path"].startswith("M 0 0")
+
+
+def test_license_gate_and_node_registration():
+    with pytest.raises(ValueError, match="License"):
+        Moondream31Loader().load(
+            False,
+            "Auto",
+            4,
+            "Balanced (8K pages)",
+        )
+    assert set(module.NODE_CLASS_MAPPINGS) == {
+        "Moondream31Loader",
+        "Moondream31Query",
+        "Moondream31Caption",
+        "Moondream31Detect",
+        "Moondream31Point",
+        "Moondream31Segment",
+    }
+    assert all(
+        node.CATEGORY == "VLM Nodes/Moondream 3"
+        for node in module.NODE_CLASS_MAPPINGS.values()
+    )
+
+
+def test_final_31_model_does_not_claim_preview_svg_segment():
+    with pytest.raises(ValueError, match="3 Preview"):
+        Moondream31Segment().segment(
+            _fake_model(lambda *_args, **_kwargs: {}),
+            torch.zeros((1, 16, 16, 3)),
+            "object",
+            1.0,
+            1,
+            1,
+            1,
+            False,
+        )
+
+
+def test_worker_auth_is_not_exposed_in_process_arguments_and_logs_are_redacted(
+    tmp_path,
+    monkeypatch,
+):
+    source = inspect.getsource(Moondream31Model.ensure_started)
+    assert '"--auth-key"' not in source
+    assert "MOONDREAM_WORKER_AUTH" in inspect.getsource(
+        module._worker_environment
+    )
+    log = tmp_path / "worker.log"
+    log.write_text(
+        "api_key=secret-value\nAuthorization: bearer-value\nCUDA error",
+        encoding="utf-8",
+    )
+    tail = module._safe_log_tail(log)
+    assert "secret-value" not in tail
+    assert "bearer-value" not in tail
+    assert "CUDA error" in tail
+
+    monkeypatch.setenv("PATH", "/runtime/bin")
+    monkeypatch.setenv("OPENAI_API_KEY", "must-not-cross")
+    monkeypatch.setenv("HF_TOKEN", "hf-server-side")
+    monkeypatch.setenv("MOONDREAM_API_KEY", "adapter-only")
+    monkeypatch.setenv("HTTPS_PROXY", "https://user:password@example.test")
+    base_environment = module._worker_environment(
+        tmp_path,
+        b"\x01" * 32,
+        module.MODEL_ID,
+    )
+    assert base_environment["PATH"] == "/runtime/bin"
+    assert base_environment["HF_TOKEN"] == "hf-server-side"
+    assert "OPENAI_API_KEY" not in base_environment
+    assert "MOONDREAM_API_KEY" not in base_environment
+    assert "HTTPS_PROXY" not in base_environment
+    assert base_environment["MOONDREAM_WORKER_AUTH"] == "01" * 32
+
+    adapter_environment = module._worker_environment(
+        tmp_path,
+        b"\x02" * 32,
+        f"{module.MODEL_ID}/adapter@step",
+    )
+    assert adapter_environment["MOONDREAM_API_KEY"] == "adapter-only"
+
+
+def test_runtime_python_preserves_virtualenv_symlink(tmp_path, monkeypatch):
+    root = tmp_path / "runtime"
+    binary = tmp_path / "base-python"
+    binary.write_text("", encoding="utf-8")
+    venv_python = root / ".venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    try:
+        venv_python.symlink_to(binary)
+    except OSError:
+        pytest.skip("This filesystem cannot create symlinks.")
+    monkeypatch.delenv("MOONDREAM_PYTHON", raising=False)
+    selected = module._runtime_python(root)
+    assert selected == venv_python.absolute()
+    assert selected != binary.resolve()
+
+
+def test_worker_registers_official_31_id_only_when_upstream_is_missing(
+    monkeypatch,
+):
+    @dataclass(frozen=True)
+    class Spec:
+        name: str
+        repo_id: str
+        filename: str
+        checkpoint_format: str
+
+    registry = {
+        "moondream3-preview": Spec(
+            "moondream3-preview",
+            "moondream/moondream3-preview",
+            "model_fp8.pt",
+            "md3",
+        )
+    }
+    fake = types.ModuleType("kestrel.models")
+    fake.get_spec = lambda name: (
+        registry[name] if name in registry else (_ for _ in ()).throw(ValueError(name))
+    )
+    fake.register = lambda spec: registry.__setitem__(spec.name, spec)
+    monkeypatch.setitem(sys.modules, "kestrel.models", fake)
+
+    assert worker._register_moondream31_if_needed("moondream3.1-9B-A2B")
+    registered = registry["moondream3.1-9B-A2B"]
+    assert registered.repo_id == "moondream/moondream3.1-9B-A2B"
+    assert registered.filename == "model.safetensors"
+    assert registered.checkpoint_format == "md3"
+    assert not worker._register_moondream31_if_needed("moondream3.1-9B-A2B")
+    assert not worker._register_moondream31_if_needed("custom-model")

--- a/web/js/viewText.js
+++ b/web/js/viewText.js
@@ -5,6 +5,8 @@ const OUTPUT_NAME = "output_text";
 const VIEW_TEXT_NODE = "ViewText";
 const STREAMING_SOURCE_NODES = new Set([
     "ModernVLM",
+    "Moondream31Query",
+    "Moondream31Caption",
     "PromptGenerateAPI",
     "HostedVLMAPI",
     "VLMVideoTemporalReasoner",


### PR DESCRIPTION
## Summary

- add portable VLM performance profiles and a model-agnostic pixel-budget node
- optimize the existing track-aware video sampler's full-resolution memory path
- serialize per-node model cache creation to prevent duplicate concurrent loads
- add isolated Moondream 3/3.1 Photon query, caption, detection, pointing, streaming, and measured video throughput
- preserve Moondream 3 Preview native SVG segmentation as masks, cutouts, overlays, polygons, and canonical detections
- separate final 3.1 capabilities from the Preview segment skill and reject mismatches before inference
- keep Photon dependencies isolated, filter unrelated provider credentials, hide the random IPC key from process arguments, and reclaim the exact worker process
- add API examples and cross-platform/license/runtime documentation

## Validation

- 190 tests pass (24 	est_nodes.py tests + 166 remaining tests)
- live ComfyUI /object_info registration checked for every new node
- real 121-frame lm_api_people_birds.mp4 API graph passed through core video decode, adaptive sampling, pixel budgeting, previews, and ViewText reports (cdbc206-96ce-4fea-9840-b13fecd8f95f)
- real 1280x720 pre-inference benchmark reduced frame×pixel work by 11.38x in the tested 60-frame/10-frame configuration; this is explicitly documented as workload reduction, not a universal inference-speed claim
- official Moondream 3.1 weights were downloaded and startup was probed once; the current RTX 3090 host's NVIDIA driver lacks Photon's required cudaLibraryLoadData symbol. The worker now reports this exact sanitized error and exits without taking down ComfyUI or leaving a process behind (6188433a-b66c-43e9-87b0-393bb1666eba).
