### PR TITLE
Fix SmolVLM setup dependencies

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -173,6 +173,15 @@ python -m pip install llama-cpp-python \
   --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/vulkan
 ```
 
+If an Apple Metal wheel is unavailable or fails archive validation, build the
+same optional requirement from source:
+
+```bash
+CMAKE_ARGS="-DGGML_METAL=on" python -m pip install \
+  --no-cache-dir --no-binary llama-cpp-python \
+  -r ComfyUI/custom_nodes/ComfyUI_VLM_nodes/requirements-llama-cpp.txt
+```
+
 The official Windows HIP Radeon index is:
 
 ```powershell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "huggingface-hub>=1.5,<2",
   "httpx>=0.27,<1",
   "jsonschema>=4.22,<5",
+  "num2words>=0.5.14,<1",
   "openai>=2,<3",
   "pydantic>=2.7,<3",
   "qwen-vl-utils>=0.0.14",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ einops>=0.8,<1
 huggingface-hub>=1.5,<2
 httpx>=0.27,<1
 jsonschema>=4.22,<5
+num2words>=0.5.14,<1
 openai>=2,<3
 pydantic>=2.7,<3
 qwen-vl-utils>=0.0.14

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -120,6 +120,10 @@ def test_dependency_metadata_matches_installer_requirements():
         if line.strip() and not line.lstrip().startswith("#")
     }
     assert project_requirements == installer_requirements
+    assert any(
+        Requirement(value).name == "num2words"
+        for value in metadata["project"]["dependencies"]
+    )
 
     bitsandbytes = next(
         Requirement(value)


### PR DESCRIPTION
## Summary

- declare `num2words`, which the Transformers SmolVLM processor requires at runtime
- keep `requirements.txt` and `pyproject.toml` aligned and protect the dependency with a regression assertion
- document the Apple Metal source-build fallback when a llama-cpp-python wheel is unavailable or fails archive validation

## Validation

- `193 passed`
- `uv pip check`: all installed packages compatible
- real SmolVLM2 256M Transformers inference on Apple M3/MPS
- real SmolVLM2 256M Q8 GGUF + MTMD projector inference with llama-cpp-python 0.3.34 and Metal GPU offload