### PR TITLE
feat: add robotics VLA policy toolkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ Versions are published to the [Comfy Registry](https://registry.comfy.org/)
 from `pyproject.toml`. A release is only published when `version` changes, so
 every user-visible fix needs a version bump.
 
+## [3.4.0] - 2026-07-31
+
+### Added
+
+- A robotics-safe VLA layer with typed embodiment, observation, and action
+  contracts; bounded multi-camera history; trajectory inspection and preview;
+  action-chunk replanning; and explicit bounds, rate, dimension, horizon, and
+  non-finite-value checks before handoff.
+- Native policy clients for OpenPI's WebSocket protocol and NVIDIA Isaac
+  GR00T's ZeroMQ protocol, plus a portable authenticated HTTP/JPEG protocol for
+  isolated policy runtimes.
+- An isolated current-LeRobot policy server with pre/postprocessor support,
+  serialized inference, optional idle CPU offload, checkpoint feature metadata,
+  and environment-only bearer authentication.
+- A curated 15-model VLA catalog covering SmolVLA, X-VLA, the OpenPI family,
+  GR00T N1.7, WALL-OSS, MolmoAct2, VLA-JEPA, LingBot-VA, FastWAM, EO-1, EVO-1,
+  OpenVLA-OFT, and Octo with explicit readiness and fine-tuning requirements.
+- A complete API workflow, setup guide, compatibility matrix, security
+  guidance, and real-weight SmolVLA validation on an RTX 3090.
+
+### Security
+
+- Workflow JSON never stores robotics API keys. The clients read only
+  `VLA_POLICY_TOKEN`, `OPENPI_API_KEY`, or `GROOT_API_TOKEN` from the
+  environment, redact them from errors/reports, reject embedded URL
+  credentials, and require encrypted transports plus explicit opt-in for
+  remote endpoints where the upstream protocol supports encryption.
+- The included policy server bounds request, camera, history, and response
+  sizes and never uses pickle across the network.
+
 ## [3.3.1] - 2026-07-30
 
 ### Fixed
@@ -142,6 +172,7 @@ Tagging began at 3.3.0. Earlier versions link to the commit that declared
 them, because retroactively tagging them would run current CI against code
 that predates it.
 
+[3.4.0]: https://github.com/gokayfem/ComfyUI_VLM_nodes/compare/v3.3.1...v3.4.0
 [3.3.1]: https://github.com/gokayfem/ComfyUI_VLM_nodes/compare/v3.3.0...v3.3.1
 [3.3.0]: https://github.com/gokayfem/ComfyUI_VLM_nodes/releases/tag/v3.3.0
 [3.2.0]: https://github.com/gokayfem/ComfyUI_VLM_nodes/commit/44fefcb

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -137,6 +137,38 @@ Authoritative references:
 - Model downloads, imports, and package compilation never occur during node
   discovery.
 
+## Robotics / VLA policy compatibility
+
+ComfyUI's robotics schemas, safety gate, trajectory tools, and universal HTTP
+client run wherever this node pack runs. Policy runtime compatibility is
+separate:
+
+| Policy route | ComfyUI client | Policy environment | Practical boundary |
+| --- | --- | --- | --- |
+| Universal VLA HTTP | Windows, Linux, macOS; CUDA, ROCm, Metal, XPU, CPU | Any host that implements `comfyui-vla-http-v1` | Loopback HTTP or trusted HTTPS; no pickle |
+| LeRobot sidecar | Same universal client | Current LeRobot supports Linux, Windows, and macOS; individual policy extras/operators vary | Python/PyTorch live outside ComfyUI; fine-tuned checkpoint required for the target embodiment |
+| openpi WebSocket | Lightweight optional client on every ComfyUI platform | Upstream currently tests Ubuntu 22.04 + NVIDIA, inference above 8 GB VRAM | Use WSL/Docker/Linux server; remote transport must be WSS |
+| Isaac-GR00T N1.7 ZMQ | Lightweight optional client on every ComfyUI platform | NVIDIA CUDA/Jetson Linux according to upstream deployment matrix | ZMQ has no transport encryption; use a private network/tunnel |
+| OpenVLA-OFT | Universal client with a project-specific bridge | Upstream PyTorch/CUDA environment | OFT is the preferred high-frequency multi-image OpenVLA route |
+| Octo | Universal client with a project-specific bridge | Isolated JAX environment | Kept as a lightweight research baseline, not the default maintained runtime |
+
+Install only the native client protocols into ComfyUI:
+
+```bash
+python -m pip install -r requirements-robotics-client.txt
+```
+
+Do not install `lerobot[all]`, openpi, Isaac-GR00T, OpenVLA, or JAX into
+ComfyUI's Python. The included LeRobot HTTP sidecar belongs in its own
+environment and optionally moves its owned policy to CPU after an idle
+interval. It does not flush ComfyUI's accelerator cache.
+
+An embodiment profile is a workflow contract, not a hardware certification.
+The supplied profiles are visibly labeled templates. Before real deployment,
+replace action bounds/deltas with the trained dataset's semantics and the
+manufacturer/controller limits. ComfyUI never opens ROS, serial, CAN, or robot
+SDK transports.
+
 Install manually:
 
 ```bash

--- a/MODEL_VALIDATION.md
+++ b/MODEL_VALIDATION.md
@@ -21,6 +21,71 @@ One checkpoint covers sibling sizes that use the same architecture and loader.
 The node does not download every size simply to repeat the same integration
 test.
 
+## Robotics VLA pass
+
+Validated on 2026-07-31 through the included isolated LeRobot HTTP policy
+server, entirely from WSL and D-drive storage:
+
+- Runtime: Python 3.12.12, LeRobot 0.6.1 from current upstream source,
+  PyTorch 2.11.0+cu128, and an NVIDIA RTX 3090.
+- Checkpoint: `lerobot/smolvla_base` (about 2.5 GiB of D-drive cache), backed
+  by `HuggingFaceTB/SmolVLM2-500M-Video-Instruct`.
+- Real input: local `image (23).png`, a 256x256 outdoor photograph, repeated
+  across the checkpoint's three declared camera keys with a six-value state
+  vector and the task “Move the end effector toward the backpack and prepare
+  to grasp it.”
+- Contract: three camera tensors, `observation.state`, the LeRobot
+  preprocessor, `predict_action_chunk`, the checkpoint postprocessor, bounded
+  JSON/JPEG transport, action parsing, and the ComfyUI safety layer all ran.
+  The native checkpoint advertises a 50-step chunk; the server returned four
+  steps of six actions for this test.
+- Five warm requests after one discarded warm-up measured 241.374 ms mean
+  server inference (242.957 ms median, 234.726–249.980 ms range) and
+  270.404 ms mean HTTP client time (271.483 ms median,
+  261.477–282.218 ms range).
+- The final raw action chunk was:
+
+  ```json
+  [
+    [0.06258623, -0.11250310, -0.13713294, -0.06168950, -0.00926633, -0.08506130],
+    [0.15420279, -0.05678255, -0.20159233, 0.06734322, -0.00563951, -0.09575561],
+    [0.16482556, -0.07453565, -0.17410603, 0.02461835, -0.00256573, 0.15842065],
+    [0.27048433, -0.09272483, -0.19934477, 0.05491992, 0.05286619, 0.07594281]
+  ]
+  ```
+
+  Applying the SO-100/SO-101 template limits from an all-zero previous action
+  found five per-step delta violations, no bounds violations, and no
+  non-finite values. `Clamp safely` produced:
+
+  ```json
+  [
+    [0.06258623, -0.1, -0.1, -0.06168950, -0.00926633, -0.08506130],
+    [0.15420279, -0.05678255, -0.2, 0.03831051, -0.00563951, -0.09575561],
+    [0.16482556, -0.07453565, -0.17410603, 0.02461835, -0.00256573, 0.05424440],
+    [0.26482555, -0.09272483, -0.19934477, 0.05491992, 0.05286619, 0.07594281]
+  ]
+  ```
+
+This is an end-to-end loading, preprocessing, inference, transport, parsing,
+and safety-contract pass. It is not evidence that a base SmolVLA checkpoint can
+control an SO-100 from an arbitrary Internet-style photograph. Actual robot
+deployment still requires embodiment-matched fine-tuning, calibrated state and
+camera inputs, hardware-certified limits, a deadman/watchdog, collision
+handling, and an external emergency stop.
+
+The same real checkpoint was then exercised through ComfyUI's actual local
+`POST /prompt` API, not by calling the Python node directly. The graph loaded
+and center-cropped the real image to 256x256, constructed the three-camera
+checkpoint contract, called the isolated GPU policy, applied the SO-100/SO-101
+template safety gate, rendered a 960x480 trajectory preview, and emitted all
+three text reports. Final prompt
+`86b31f5a-5a8c-4abc-abdb-634e46da5c93` completed successfully: the policy
+returned `[4, 6]` actions, the safety gate found three rate violations and
+clamped them, `safe_for_handoff` was true under the declared template, and
+ComfyUI wrote preview `ComfyUI_temp_icynu_00001_.png`. The reusable acceptance
+harness is `tests/manual_robotics_smoke.py`.
+
 ## ComfyUI API pass
 
 ComfyUI started from the D-drive WSL installation with all four repaired custom

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ComfyUI VLM Nodes
 
 Production-oriented vision-language, structured prompting, audio, and utility
-nodes for ComfyUI. Version 3.3 supports ComfyUI's selected NVIDIA CUDA, AMD
+nodes for ComfyUI. Version 3.4 supports ComfyUI's selected NVIDIA CUDA, AMD
 ROCm, Apple Metal, Intel XPU, and CPU device without replacing its PyTorch
 build. It removes startup installers and global accelerator cache flushes,
 adds real image/video batches and live token streaming, and uses ComfyUI model
@@ -340,6 +340,9 @@ API-format examples are in [`examples/vision`](examples/vision):
 
 The dependency-free text-toolkit example is
 [`examples/text_toolkit_api.json`](examples/text_toolkit_api.json).
+Robotics policy, safety, and sidecar examples are in
+[`examples/robotics`](examples/robotics), including a complete universal
+HTTP policy graph.
 
 Upload the named media to ComfyUI's input directory, adjust the filenames and
 labels, then submit the JSON object as the `prompt` value to `/prompt`. These
@@ -347,7 +350,7 @@ are API graphs, not frontend workflow-export JSON.
 
 ## Node reference
 
-All 78 registered nodes, grouped by their menu category. The **Node ID** is the
+All 89 registered nodes, grouped by their menu category. The **Node ID** is the
 `class_type` written into workflow and API JSON — search for that string when
 you need to find a node you saw on a canvas.
 
@@ -477,6 +480,26 @@ projector (mmproj).
 | Hosted VLM API (Secure) | `HostedVLMAPI` | `STRING`, `STRING`, `INT` |
 | Hosted LLM API (Secure) | `PromptGenerateAPI` | `STRING` |
 
+### Robotics / VLA policies
+
+These nodes build and inspect policy observations/actions. They never send
+commands to robot hardware. Heavy policy runtimes stay in isolated LeRobot,
+openpi, GR00T, OpenVLA/OFT, or JAX environments.
+
+| Node | Node ID | Outputs |
+| --- | --- | --- |
+| VLA Embodiment Profile | `VLAEmbodimentProfile` | `VLA_EMBODIMENT`, `STRING`, `INT`, `INT` |
+| VLA Observation Builder | `VLAObservationBuilder` | `VLA_OBSERVATION`, `STRING`, `INT` |
+| VLA Policy — Universal HTTP | `VLAHTTPPolicy` | `VLA_ACTIONS`, `STRING` |
+| VLA Policy — OpenPI WebSocket | `VLAOpenPIWebSocketPolicy` | `VLA_ACTIONS`, `STRING` |
+| VLA Policy — GR00T N1.7 ZMQ | `VLAGr00tZMQPolicy` | `VLA_ACTIONS`, `STRING` |
+| VLA Action Safety Gate | `VLAActionSafety` | `VLA_ACTIONS`, `STRING`, `BOOLEAN` |
+| VLA Actions From JSON | `VLAActionsFromJSON` | `VLA_ACTIONS`, `STRING` |
+| VLA Action Chunk Replan | `VLAActionChunkReplan` | `VLA_ACTIONS`, `STRING` |
+| VLA Action Inspect | `VLAActionInspect` | `STRING`, `STRING`, `INT`, `INT` |
+| VLA Trajectory Preview | `VLATrajectoryPreview` | `IMAGE` |
+| VLA Model Catalog | `VLAModelCatalog` | `STRING`, `STRING`, `STRING`, `STRING` |
+
 ### Text toolkit
 
 Dependency-free string handling, so a VLM response can be shaped without an
@@ -545,6 +568,35 @@ this repository: ComfyUI's own installer selects CUDA, ROCm, XPU, Metal, or CPU.
 Current official bitsandbytes wheels are installed automatically only on their
 supported OS/architecture combinations. Unsupported machines retain all
 non-quantized nodes.
+
+### Robotics / VLA isolated runtimes
+
+The robotics nodes keep policy dependencies outside ComfyUI. The universal
+HTTP client works without another package. Native openpi WebSocket and
+GR00T ZeroMQ clients use the lightweight optional extra:
+
+```bash
+python -m pip install \
+  -r ComfyUI/custom_nodes/ComfyUI_VLM_nodes/requirements-robotics-client.txt
+```
+
+`VLA Model Catalog` covers current SmolVLA, X-VLA, π0/π0-FAST/π0.5,
+GR00T N1.7, WALL-OSS, MolmoAct2, VLA-JEPA, LingBot-VA, FastWAM, EO-1,
+EVO-1, OpenVLA-OFT, and Octo routes. “Available” means a supported isolated
+runtime/checkpoint path; base and architecture-only entries still require
+embodiment-specific training and transforms.
+
+Start with SmolVLA for small consumer hardware. The included authenticated
+LeRobot sidecar loads one chosen policy, uses its serialized processors,
+returns action chunks over bounded JSON/JPEG, keeps it resident for speed,
+and can offload it to CPU after an idle timeout. Remote policy URLs require
+encrypted transport and explicit opt-in. Tokens are fixed environment
+variables (`VLA_POLICY_TOKEN`, `OPENPI_API_KEY`, or `GROOT_API_TOKEN`) and are
+never workflow inputs.
+
+See [`examples/robotics/README.md`](examples/robotics/README.md) for D-drive
+WSL setup, platform boundaries, current model readiness, observation schemas,
+action safety semantics, and the runnable API example.
 
 ### Moondream 3 / 3.1 isolated runtime
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,6 +40,9 @@ restart ComfyUI:
 | Together AI | `TOGETHER_API_KEY` |
 | OpenRouter | `OPENROUTER_API_KEY` |
 | Custom remote endpoint | `CUSTOM_API_KEY` |
+| Universal VLA policy server | `VLA_POLICY_TOKEN` |
+| openpi WebSocket server | `OPENPI_API_KEY` |
+| Isaac-GR00T ZMQ server | `GROOT_API_TOKEN` |
 
 For an interactive POSIX/WSL session, this avoids putting the value in shell
 history:
@@ -58,6 +61,38 @@ Web search is disabled by default. Enabling it sends the request content to the
 selected provider's server-side search system and may have separate retention,
 regional-availability, and billing terms. Treat it as an explicit data-sharing
 choice; do not enable it for content that is outside those terms.
+
+## Robotics policy endpoints
+
+Robotics tokens are also server-side only. Workflow nodes select an endpoint,
+but cannot select an arbitrary environment variable or contain the secret
+value.
+
+- The universal policy client permits unencrypted HTTP only on loopback.
+  Remote use requires HTTPS plus `allow_remote=true`; redirects and
+  environment proxies are disabled.
+- The openpi client permits unencrypted WebSocket only on loopback. Remote use
+  requires WSS plus `allow_remote=true`.
+- GR00T's official ZeroMQ protocol has token authentication but no built-in
+  transport encryption. Keep it on loopback/private infrastructure or place it
+  inside an authenticated encrypted tunnel. Never expose its port directly to
+  the public internet.
+- Camera payloads are JPEG-compressed and bounded per frame and per request.
+  Response sizes, camera count, observation history, state/action dimensions,
+  and action horizons are bounded before use.
+- MessagePack ndarray decoders reject object/void dtypes and never deserialize
+  pickle. The included HTTP sidecar uses bounded JSON instead of LeRobot's
+  pickle-based asynchronous transport.
+- Errors redact the resolved token and authorization-like values. Reports
+  include only endpoint scheme/host/port, not request headers, full camera
+  payloads, or state data.
+
+Robot observations may expose people, homes, workplaces, proprietary tasks,
+and physical state. Treat them as sensitive even when no API key is present.
+The safety node is a data validation gate, not a certified control system.
+This package intentionally contains no ROS, serial, CAN, motor, or robot SDK
+transport; a separate controller must enforce emergency stop, deadman,
+watchdog, collision/workspace, command-age, and manufacturer limits.
 
 ## Legacy workflows
 

--- a/__init__.py
+++ b/__init__.py
@@ -26,6 +26,7 @@ node_list = [
     "paligemma",
     "playmusic",
     "qwen2vl",
+    "robotics",
     "sam2",
     "sam3_adapter",
     "simpletext",

--- a/examples/robotics/README.md
+++ b/examples/robotics/README.md
@@ -1,0 +1,266 @@
+# Robotics and VLA workflows
+
+The robotics nodes make ComfyUI a policy-development, inspection, and
+simulation surface. They do **not** send commands to motors, ROS, CAN, serial,
+or a robot SDK.
+
+The boundary is intentional:
+
+```text
+camera/state/task
+      |
+      v
+VLA Observation Builder
+      |
+      v
+isolated policy server  --->  raw action chunk
+                                  |
+                                  v
+                         VLA Action Safety Gate
+                                  |
+                    +-------------+-------------+
+                    |                           |
+                    v                           v
+            inspect / plot / record      simulator or your own
+                                         supervised controller bridge
+```
+
+A real controller bridge must independently enforce a deadman, watchdog,
+emergency stop, collision/workspace limits, timestamps, command freshness, and
+the manufacturer's limits. A `safe_for_handoff=true` workflow result only
+means that the declared ComfyUI profile checks passed.
+
+## Why policy runtimes are isolated
+
+LeRobot, openpi, Isaac-GR00T, OpenVLA/OFT, and Octo use different PyTorch/JAX,
+CUDA, Transformers, compiler, and operating-system combinations. Installing
+all of those into ComfyUI would replace or constrain the working accelerator
+stack and make Windows, macOS, ROCm, and XPU support worse.
+
+The ComfyUI package therefore contains only:
+
+- typed state/action/camera contracts;
+- bounded image serialization;
+- a dependency-light universal HTTPS/loopback HTTP client;
+- exact clients for the official openpi MessagePack WebSocket and GR00T
+  MessagePack/ZeroMQ protocols;
+- action validation, horizon control, inspection, and plotting.
+
+The heavyweight policy stays in its own process, container, WSL distribution,
+Linux machine, Mac, or GPU server. This also allows ComfyUI to use AMD ROCm,
+Apple Metal, Intel XPU, or CPU while a policy runs on an NVIDIA Linux server.
+
+## Fast path: SmolVLA through the universal sidecar
+
+Use a separate LeRobot environment. Current LeRobot documentation recommends
+Python 3.12 and exposes policy-specific extras. On this computer, keep it on
+the D drive:
+
+```bash
+# WSL
+python3.12 -m venv /mnt/d/vla-runtime/lerobot-smolvla
+source /mnt/d/vla-runtime/lerobot-smolvla/bin/activate
+python -m pip install --upgrade pip
+python -m pip install "lerobot[smolvla]"
+
+export VLA_POLICY_TOKEN="$(python -c 'import secrets; print(secrets.token_urlsafe(32))')"
+python /mnt/d/ComfyUI_windows_portable/ComfyUI/custom_nodes/ComfyUI_VLM_nodes/examples/robotics/lerobot_policy_server.py \
+  --policy-type smolvla \
+  --policy-path YOUR_FINE_TUNED_SMOLVLA_CHECKPOINT \
+  --device auto \
+  --actions-per-chunk 16 \
+  --idle-offload-seconds 300
+```
+
+Set the same `VLA_POLICY_TOKEN` in the environment that launches ComfyUI.
+Never put it in a workflow. In `VLA Policy — Universal HTTP`, use
+`http://127.0.0.1:8787`.
+
+`lerobot/smolvla_base` is a base model. It is a useful fine-tuning starting
+point, not a universal zero-shot controller. Use an embodiment-specific
+checkpoint whose feature names, action dimensions, state dimensions,
+normalization statistics, and camera keys match the workflow.
+
+The sidecar:
+
+- loads only the chosen policy and its serialized pre/post-processors;
+- uses `predict_action_chunk` when provided and falls back to `select_action`;
+- keeps the model resident by default for low latency;
+- can move it to CPU after an idle interval and move it back on demand;
+- accepts one request at a time per policy, preventing stateful policy races;
+- uses bounded JSON/JPEG rather than pickle;
+- never returns tracebacks, environment variables, request data, or
+  authorization headers.
+
+For a real local API acceptance run, start ComfyUI and the policy sidecar, put
+an image in ComfyUI's `input` directory, then run:
+
+```bash
+python tests/manual_robotics_smoke.py \
+  --comfy-url http://127.0.0.1:8188 \
+  --policy-url http://127.0.0.1:8787 \
+  --image robot_front.png
+```
+
+The script queues the graph through `POST /prompt`, waits on its history entry,
+and prints the policy report, safety report, first action, and preview filename.
+
+Install the relevant official LeRobot extra for another policy. Examples are
+`lerobot[pi]` for π0/π0.5/π0-FAST and `lerobot[smolvla]` for SmolVLA. Some
+newer policy integrations may require installing current LeRobot from source
+with their documented extra.
+
+## Native openpi server
+
+Install the small ComfyUI client dependencies:
+
+```bash
+python -m pip install -r requirements-robotics-client.txt
+```
+
+Run the official openpi policy WebSocket server in its own supported
+environment. The upstream runtime is currently tested on Ubuntu 22.04 and an
+NVIDIA GPU with more than 8 GB for inference; use WSL/Docker or a remote Linux
+server rather than forcing it into a macOS/Windows ComfyUI environment.
+
+Use:
+
+- `Flat keys (DROID / LIBERO)` for observations such as
+  `observation/image`, `observation/wrist_image`, and `observation/state`;
+- `Nested images (ALOHA)` for `state`, an `images` mapping such as
+  `cam_high`/wrist cameras, and `prompt`.
+
+The workflow supplies key names, but the policy's own transform still defines
+the exact shapes and normalization. `OPENPI_API_KEY` is read only from the
+ComfyUI server environment. Remote endpoints require WSS and explicit
+`allow_remote=true`.
+
+## Native Isaac-GR00T N1.7 server
+
+Install the same lightweight robotics client requirements in ComfyUI. Run the
+official GR00T `PolicyServer` beside an embodiment-compatible `Gr00tPolicy`.
+The node sends the documented nested contract:
+
+```text
+video.<camera>     uint8  [batch=1, history, height, width, RGB=3]
+state.state        float32[batch=1, history, state_dim]
+language.task      string [batch=1, 1]
+```
+
+The official server returns one or more physical-unit action streams with
+shape `[batch, horizon, dimension]`. The node flattens those streams while
+preserving their named slices. `GROOT_API_TOKEN` remains in the ComfyUI
+environment.
+
+GR00T N1.7 currently targets NVIDIA CUDA/Jetson Linux and needs an
+embodiment-compatible base or post-trained checkpoint. A ComfyUI client on
+Windows, macOS, ROCm, or another machine may call that server over a trusted
+network, but remote access must be explicitly enabled. Native GR00T ZMQ does
+not encrypt traffic; use a private authenticated network/tunnel. Prefer the
+universal HTTPS bridge when transport-layer encryption is required.
+
+## Model catalog: what “available” means
+
+`VLA Model Catalog` distinguishes these states:
+
+| Family | Example checkpoint | Route | Important qualification |
+| --- | --- | --- | --- |
+| SmolVLA | `lerobot/smolvla_base` | LeRobot HTTP sidecar | 450M and the best small starting point; fine-tune for the robot |
+| X-VLA | `lerobot/xvla-base` | LeRobot HTTP sidecar | 0.9B cross-embodiment base; use a matching domain checkpoint |
+| π0 | `lerobot/pi0_base` | LeRobot or openpi | Base/fine-tuning model, not a universal drop-in controller |
+| π0-FAST | `lerobot/pi0fast-base` | LeRobot or openpi | Faster tokenized action generation |
+| π0.5 | `lerobot/pi05_base` | LeRobot or openpi | Open-world generalization; still embodiment-specific |
+| GR00T N1.7 | `nvidia/GR00T-N1.7-3B` | GR00T ZMQ or LeRobot | Base has specific zero-shot tags; other robots need post-training |
+| X-Square WALL-OSS | `x-square-robot/wall-oss-flow` | LeRobot HTTP sidecar | MoE research model; validate checkpoint terms and embodiment |
+| MolmoAct2 | `lerobot/MolmoAct2-SO100_101-LeRobot` | LeRobot HTTP sidecar | Converted SO-100/SO-101 checkpoint |
+| VLA-JEPA | `lerobot/VLA-JEPA-Pretrain` | LeRobot HTTP sidecar | DROID pretrain plus LIBERO/SimplerEnv checkpoints |
+| LingBot-VA | `lerobot/lingbot_va_base` | LeRobot HTTP sidecar | Prefer its LIBERO-Long/RoboTwin post-train where applicable |
+| FastWAM | released LIBERO checkpoint | LeRobot HTTP sidecar | Heavy world-action research runtime |
+| EO-1 / EVO-1 | your trained checkpoint | LeRobot HTTP sidecar | Architecture support, not a universal ready-made controller |
+| OpenVLA-OFT | compatible OFT fine-tune | dedicated sidecar | OFT is the faster multi-image/high-frequency OpenVLA route |
+| Octo small | Octo small 27M | dedicated JAX sidecar | Lightweight legacy research baseline |
+
+The catalog is a verified runtime/checkpoint map, not a promise that a base
+checkpoint understands an arbitrary robot. Exact data transforms and
+fine-tuning are part of the policy.
+
+## Observation history and real-time use
+
+Connect an `IMAGE` batch to a camera input to represent temporal history. All
+camera batches must have the same length, although a one-frame camera may
+broadcast. Use:
+
+`Video Slice` → `VLM Adaptive Frame Sampler` or a live capture source →
+`VLM Image Pixel Budget` → `VLA Observation Builder`
+
+For closed-loop robotics, do not run an unbounded ComfyUI queue for each motor
+tick. Use ComfyUI to prototype and inspect the observation/policy/safety
+contract, and use the policy runtime's asynchronous control support for the
+actual high-frequency loop. LeRobot supports asynchronous action chunks and
+GR00T supports TensorRT deployment; both are better places for timing-critical
+execution.
+
+## Action safety semantics
+
+The `VLA Action Safety Gate` checks:
+
+- policy action dimension against the embodiment;
+- NaN and infinity;
+- minimum and maximum values;
+- maximum change per action dimension and control step;
+- the requested execution horizon.
+
+Modes:
+
+- `Block unsafe`: raise and stop the workflow on any violation.
+- `Clamp safely`: replace non-finite values conservatively, then clamp bounds
+  and sequential per-step deltas.
+- `Hold position on unsafe`: replace the whole chunk with the explicitly
+  supplied previous/current command.
+- `Report only`: preserve the raw trajectory and set
+  `safe_for_handoff=false`.
+
+For delta-action policies, `previous_action_json` means the previous delta
+command, not an absolute joint pose. Define the profile in the same units and
+semantics as the policy output.
+
+`VLA Actions From JSON` imports recorded/simulator trajectories without a
+network policy. `VLA Action Chunk Replan` blends the unexecuted edge of an old
+chunk into a new chunk to reduce discontinuities, then the result should pass
+through the safety gate again. This deterministic blend is useful for workflow
+experiments but does not replace LeRobot's asynchronous controller or a
+policy-specific real-time chunking implementation.
+
+## API example
+
+`vla_http_policy_safety_api.json` is a ComfyUI API prompt graph. Put
+`robot_front.png` in `ComfyUI/input`, start a compatible sidecar, then POST:
+
+```json
+{"prompt": {"...": "contents of vla_http_policy_safety_api.json"}}
+```
+
+It builds an observation, calls the policy, clamps it against the explicit
+profile, renders the trajectory, and outputs both inference and safety JSON.
+
+## Security checklist
+
+- Keep all policy tokens in environment variables.
+- Leave `allow_remote=false` for local servers.
+- Remote universal endpoints must use HTTPS; remote openpi endpoints must use
+  WSS.
+- Never expose GR00T ZMQ directly to an untrusted network.
+- Pin checkpoint revisions when reproducibility matters.
+- Treat camera images, task language, and robot state as sensitive data.
+- Do not connect action JSON directly to hardware without a separate
+  supervised controller bridge and independent safety system.
+
+Authoritative upstream documentation:
+
+- [LeRobot installation](https://huggingface.co/docs/lerobot/main/en/installation)
+- [LeRobot SmolVLA](https://huggingface.co/docs/lerobot/smolvla)
+- [LeRobot asynchronous inference](https://huggingface.co/docs/lerobot/async)
+- [Physical Intelligence openpi](https://github.com/Physical-Intelligence/openpi)
+- [NVIDIA Isaac-GR00T](https://github.com/NVIDIA/Isaac-GR00T)
+- [OpenVLA and OFT](https://github.com/openvla/openvla)
+- [Octo](https://github.com/octo-models/octo)

--- a/examples/robotics/__init__.py
+++ b/examples/robotics/__init__.py
@@ -1,0 +1,1 @@
+"""Runnable, dependency-isolated robotics policy bridge examples."""

--- a/examples/robotics/lerobot_policy_server.py
+++ b/examples/robotics/lerobot_policy_server.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python
+"""Isolated LeRobot policy server for the ComfyUI VLA HTTP node.
+
+Run this file in a dedicated environment that contains LeRobot and the
+policy-specific dependencies.  Do not install LeRobot's full dependency stack
+into ComfyUI merely to use this bridge.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hmac
+import io
+import json
+import os
+import threading
+import time
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+import numpy as np
+import torch
+from PIL import Image
+
+MAX_REQUEST_BYTES = 64 * 1024 * 1024
+MAX_CAMERAS = 16
+MAX_FRAMES_PER_CAMERA = 256
+MAX_IMAGE_BYTES = 8 * 1024 * 1024
+MAX_IMAGE_PIXELS = 16 * 1024 * 1024
+MAX_STATE_DIM = 2_048
+MAX_ACTION_DIM = 2_048
+MAX_TASK_CHARS = 16_384
+
+
+def _json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _device(value: str) -> str:
+    if value != "auto":
+        return value
+    if torch.cuda.is_available():
+        return "cuda"
+    if hasattr(torch, "xpu") and torch.xpu.is_available():
+        return "xpu"
+    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+def _decode_image(frame: dict[str, Any]) -> np.ndarray:
+    if frame.get("encoding") != "base64-jpeg":
+        raise ValueError("Only base64-jpeg camera frames are supported.")
+    raw = base64.b64decode(frame["data"], validate=True)
+    if len(raw) > MAX_IMAGE_BYTES:
+        raise ValueError("Encoded camera frame exceeds the 8 MiB safety limit.")
+    with Image.open(io.BytesIO(raw)) as image:
+        if image.width * image.height > MAX_IMAGE_PIXELS:
+            raise ValueError("Decoded camera frame exceeds the pixel safety limit.")
+        return np.asarray(image.convert("RGB"), dtype=np.uint8).copy()
+
+
+def _decode_observation(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("schema") != "comfyui-vlm/robot-observation":
+        raise ValueError("Unsupported observation schema.")
+    if int(payload.get("version", 0)) != 1:
+        raise ValueError("Unsupported observation schema version.")
+    cameras = payload.get("cameras")
+    if not isinstance(cameras, dict) or not 1 <= len(cameras) <= MAX_CAMERAS:
+        raise ValueError("cameras must contain between 1 and 16 entries.")
+    observation: dict[str, Any] = {}
+    for key, encoded_frames in cameras.items():
+        key = str(key).strip()
+        if not key or len(key) > 256 or any(ord(char) < 32 for char in key):
+            raise ValueError("Camera names must contain 1 to 256 printable characters.")
+        if not isinstance(encoded_frames, list) or not (
+            1 <= len(encoded_frames) <= MAX_FRAMES_PER_CAMERA
+        ):
+            raise ValueError(f"Camera {key!r} has an invalid history.")
+        # Current LeRobot policy processors accept one current observation.
+        # ComfyUI may send history for servers/models that use it; this generic
+        # bridge deliberately selects the latest frame.
+        array = _decode_image(encoded_frames[-1])
+        tensor = torch.from_numpy(array).permute(2, 0, 1).to(torch.float32) / 255.0
+        observation[key] = tensor.unsqueeze(0)
+    state = np.asarray(payload.get("state"), dtype=np.float32)
+    if (
+        state.ndim != 1
+        or not 1 <= state.size <= MAX_STATE_DIM
+        or not np.isfinite(state).all()
+    ):
+        raise ValueError(f"state must contain 1 to {MAX_STATE_DIM} finite values.")
+    observation["observation.state"] = torch.from_numpy(state).unsqueeze(0)
+    task = str(payload.get("task", "")).strip()
+    if not task or len(task) > MAX_TASK_CHARS:
+        raise ValueError(f"task must contain 1 to {MAX_TASK_CHARS} characters.")
+    observation["task"] = task
+    return observation
+
+
+def _postprocess_chunk(postprocessor, action: torch.Tensor) -> torch.Tensor:
+    if action.ndim == 1:
+        action = action.unsqueeze(0)
+    if action.ndim == 2:
+        # select_action normally returns [batch, dim].
+        processed = postprocessor(action)
+        if processed.ndim == 1:
+            processed = processed.unsqueeze(0)
+        return processed.unsqueeze(1) if processed.ndim == 2 else processed
+    if action.ndim != 3:
+        raise ValueError(f"Policy returned unsupported action shape {tuple(action.shape)}.")
+    processed_steps = [postprocessor(action[:, index, :]) for index in range(action.shape[1])]
+    return torch.stack(processed_steps, dim=1)
+
+
+def _feature_metadata(features: Any) -> dict[str, dict[str, Any]]:
+    """Return the portable part of a LeRobot policy feature contract."""
+
+    result: dict[str, dict[str, Any]] = {}
+    for key, feature in (features or {}).items():
+        if isinstance(feature, dict):
+            feature_type = feature.get("type")
+            shape = feature.get("shape", ())
+        else:
+            feature_type = getattr(feature, "type", None)
+            shape = getattr(feature, "shape", ())
+        feature_type = getattr(feature_type, "value", feature_type)
+        dimensions: list[int | str | None] = []
+        for dimension in shape or ():
+            if dimension is None:
+                dimensions.append(None)
+                continue
+            try:
+                dimensions.append(int(dimension))
+            except (TypeError, ValueError):
+                dimensions.append(str(dimension))
+        result[str(key)] = {
+            "type": str(feature_type) if feature_type is not None else "UNKNOWN",
+            "shape": dimensions,
+        }
+    return result
+
+
+def _optional_config_int(config: Any, name: str) -> int | None:
+    value = getattr(config, name, None)
+    try:
+        return None if value is None else int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+class PolicyRuntime:
+    def __init__(
+        self,
+        *,
+        policy_type: str,
+        policy_path: str,
+        revision: str | None,
+        device: str,
+        actions_per_chunk: int,
+        idle_offload_seconds: float,
+    ):
+        self.policy_type = policy_type
+        self.policy_path = policy_path
+        self.revision = revision
+        self.device = _device(device)
+        self.actions_per_chunk = actions_per_chunk
+        self.idle_offload_seconds = idle_offload_seconds
+        self.lock = threading.Lock()
+        self.policy = None
+        self.preprocessor = None
+        self.postprocessor = None
+        self.resident_device = "unloaded"
+        self.last_request = 0.0
+        self.load_seconds = 0.0
+        self._load()
+        if idle_offload_seconds > 0 and self.device != "cpu":
+            threading.Thread(target=self._idle_worker, daemon=True).start()
+
+    def _load(self) -> None:
+        from lerobot.policies import get_policy_class, make_pre_post_processors
+
+        started = time.perf_counter()
+        policy_class = get_policy_class(self.policy_type)
+        kwargs = {}
+        if self.revision:
+            kwargs["revision"] = self.revision
+        self.policy = policy_class.from_pretrained(self.policy_path, **kwargs)
+        self.policy.eval()
+        self.policy.to(self.device)
+        overrides = {"device": self.device}
+        self.preprocessor, self.postprocessor = make_pre_post_processors(
+            self.policy.config,
+            pretrained_path=self.policy_path,
+            pretrained_revision=self.revision,
+            preprocessor_overrides={"device_processor": overrides},
+            postprocessor_overrides={"device_processor": overrides},
+        )
+        self.resident_device = self.device
+        self.last_request = time.monotonic()
+        self.load_seconds = time.perf_counter() - started
+
+    def _ensure_resident(self) -> None:
+        if self.resident_device != self.device:
+            self.policy.to(self.device)
+            self.resident_device = self.device
+
+    def _idle_worker(self) -> None:
+        interval = min(max(self.idle_offload_seconds / 4, 1.0), 30.0)
+        while True:
+            time.sleep(interval)
+            if time.monotonic() - self.last_request < self.idle_offload_seconds:
+                continue
+            if not self.lock.acquire(blocking=False):
+                continue
+            try:
+                if (
+                    self.resident_device != "cpu"
+                    and time.monotonic() - self.last_request >= self.idle_offload_seconds
+                ):
+                    self.policy.to("cpu")
+                    self.resident_device = "cpu"
+            finally:
+                self.lock.release()
+
+    def metadata(self) -> dict[str, Any]:
+        config = self.policy.config
+        return {
+            "protocol": "comfyui-vla-http-v1",
+            "policy_type": self.policy_type,
+            "policy_path": self.policy_path,
+            "revision": self.revision,
+            "configured_device": self.device,
+            "resident_device": self.resident_device,
+            "actions_per_chunk": self.actions_per_chunk,
+            "idle_offload_seconds": self.idle_offload_seconds,
+            "load_seconds": self.load_seconds,
+            "policy_contract": {
+                "input_features": _feature_metadata(
+                    getattr(config, "input_features", None)
+                ),
+                "output_features": _feature_metadata(
+                    getattr(config, "output_features", None)
+                ),
+                "observation_steps": _optional_config_int(config, "n_obs_steps"),
+                "native_chunk_size": _optional_config_int(config, "chunk_size"),
+                "native_action_steps": _optional_config_int(config, "n_action_steps"),
+            },
+        }
+
+    def infer(self, payload: dict[str, Any]) -> dict[str, Any]:
+        observation = _decode_observation(payload)
+        with self.lock:
+            self._ensure_resident()
+            started = time.perf_counter()
+            processed = self.preprocessor(observation)
+            preprocess_ms = (time.perf_counter() - started) * 1000
+            started_inference = time.perf_counter()
+            with torch.inference_mode():
+                predictor = getattr(self.policy, "predict_action_chunk", None)
+                if callable(predictor):
+                    action = predictor(processed)
+                else:
+                    action = self.policy.select_action(processed)
+            inference_ms = (time.perf_counter() - started_inference) * 1000
+            started_postprocess = time.perf_counter()
+            action = _postprocess_chunk(self.postprocessor, action)
+            if action.ndim == 3:
+                if action.shape[0] != 1:
+                    raise ValueError("Only policy batch size 1 is supported.")
+                action = action[0]
+            elif action.ndim == 1:
+                action = action.unsqueeze(0)
+            if action.ndim != 2:
+                raise ValueError(f"Unexpected final action shape {tuple(action.shape)}.")
+            action = action[: self.actions_per_chunk].detach().to("cpu", torch.float32)
+            if not 1 <= int(action.shape[1]) <= MAX_ACTION_DIM:
+                raise ValueError(
+                    f"Policy action dimension must be in [1, {MAX_ACTION_DIM}]."
+                )
+            if not torch.isfinite(action).all():
+                # Preserve the response for ComfyUI's safety node, but do not
+                # serialize non-standard JSON numbers.
+                raise ValueError("Policy returned NaN or infinite action values.")
+            postprocess_ms = (time.perf_counter() - started_postprocess) * 1000
+            self.last_request = time.monotonic()
+        return {
+            "actions": action.tolist(),
+            "server_timing": {
+                "preprocess_ms": preprocess_ms,
+                "infer_ms": inference_ms,
+                "postprocess_ms": postprocess_ms,
+            },
+            "policy": {
+                "type": self.policy_type,
+                "path": self.policy_path,
+                "device": self.device,
+            },
+        }
+
+
+class PolicyHandler(BaseHTTPRequestHandler):
+    server_version = "ComfyUI-VLA-Policy/1"
+
+    def log_message(self, format_string: str, *args: Any) -> None:
+        # The request path is safe to log. Headers and bodies may contain
+        # credentials or camera/state data and are intentionally excluded.
+        print(f"{self.address_string()} - {format_string % args}")
+
+    @property
+    def runtime(self) -> PolicyRuntime:
+        return self.server.runtime
+
+    @property
+    def token(self) -> str:
+        return self.server.token
+
+    def _authorized(self) -> bool:
+        if not self.token:
+            return True
+        supplied = self.headers.get("Authorization", "")
+        expected = f"Bearer {self.token}"
+        return hmac.compare_digest(supplied, expected)
+
+    def _send(self, status: HTTPStatus, value: Any) -> None:
+        body = _json_bytes(value)
+        self.send_response(status.value)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path not in {"/healthz", "/v1/metadata"}:
+            self._send(HTTPStatus.NOT_FOUND, {"error": "not_found"})
+            return
+        if not self._authorized():
+            self._send(HTTPStatus.UNAUTHORIZED, {"error": "unauthorized"})
+            return
+        if self.path == "/healthz":
+            self._send(HTTPStatus.OK, {"status": "ok"})
+        else:
+            self._send(HTTPStatus.OK, self.runtime.metadata())
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path != "/v1/infer":
+            self._send(HTTPStatus.NOT_FOUND, {"error": "not_found"})
+            return
+        if not self._authorized():
+            self._send(HTTPStatus.UNAUTHORIZED, {"error": "unauthorized"})
+            return
+        try:
+            content_length = int(self.headers.get("Content-Length", "0"))
+            if not 1 <= content_length <= MAX_REQUEST_BYTES:
+                raise ValueError("Request body size is invalid.")
+            body = self.rfile.read(content_length)
+            payload = json.loads(body)
+            if not isinstance(payload, dict):
+                raise ValueError("Request body must be a JSON object.")
+            result = self.runtime.infer(payload)
+        except (TypeError, ValueError, json.JSONDecodeError) as exc:
+            self._send(HTTPStatus.BAD_REQUEST, {"error": str(exc)[:1000]})
+            return
+        except Exception as exc:
+            # Do not return tracebacks, request data, environment variables, or
+            # authorization headers across the network.
+            self._send(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                {"error": f"{type(exc).__name__}: {str(exc)[:800]}"},
+            )
+            return
+        self._send(HTTPStatus.OK, result)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Serve one LeRobot policy through the ComfyUI VLA HTTP protocol."
+    )
+    parser.add_argument("--policy-type", required=True, help="LeRobot policy type, e.g. smolvla")
+    parser.add_argument("--policy-path", required=True, help="Hub repo id or local checkpoint")
+    parser.add_argument("--revision", default=None, help="Optional immutable Hub revision")
+    parser.add_argument("--device", default="auto", help="auto, cuda, mps, xpu, or cpu")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8787)
+    parser.add_argument("--actions-per-chunk", type=int, default=16)
+    parser.add_argument(
+        "--idle-offload-seconds",
+        type=float,
+        default=0.0,
+        help="Move the policy to CPU after this idle period; 0 keeps it resident.",
+    )
+    args = parser.parse_args()
+    if not 1 <= args.port <= 65_535:
+        parser.error("--port must be in [1, 65535]")
+    if not 1 <= args.actions_per_chunk <= 4096:
+        parser.error("--actions-per-chunk must be in [1, 4096]")
+    if args.idle_offload_seconds < 0:
+        parser.error("--idle-offload-seconds must be non-negative")
+
+    runtime = PolicyRuntime(
+        policy_type=args.policy_type,
+        policy_path=args.policy_path,
+        revision=args.revision,
+        device=args.device,
+        actions_per_chunk=args.actions_per_chunk,
+        idle_offload_seconds=args.idle_offload_seconds,
+    )
+    token = os.environ.get("VLA_POLICY_TOKEN", "").strip()
+    server = ThreadingHTTPServer((args.host, args.port), PolicyHandler)
+    server.runtime = runtime
+    server.token = token
+    print(
+        f"Policy ready at http://{args.host}:{args.port}/v1/infer "
+        f"(type={args.policy_type}, device={runtime.device}, auth={'on' if token else 'off'})"
+    )
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/robotics/vla_http_policy_safety_api.json
+++ b/examples/robotics/vla_http_policy_safety_api.json
@@ -1,0 +1,130 @@
+{
+  "1": {
+    "class_type": "LoadImage",
+    "inputs": {
+      "image": "robot_front.png"
+    }
+  },
+  "2": {
+    "class_type": "VLAEmbodimentProfile",
+    "inputs": {
+      "preset": "Generic 7-DoF joint + gripper",
+      "control_hz": 20.0,
+      "state_names_json": "",
+      "action_names_json": "",
+      "action_min_json": "",
+      "action_max_json": "",
+      "max_delta_json": "",
+      "camera_names_json": "",
+      "action_mode_override": ""
+    }
+  },
+  "3": {
+    "class_type": "VLAObservationBuilder",
+    "inputs": {
+      "task": "Pick up the blue cube and place it in the tray.",
+      "state_json": "[0, 0, 0, 0, 0, 0, 0, 0]",
+      "primary_image": [
+        "1",
+        0
+      ],
+      "primary_camera": "observation.images.front",
+      "history_fps": 10.0,
+      "timestamp": 0.0,
+      "embodiment": [
+        "2",
+        0
+      ]
+    }
+  },
+  "4": {
+    "class_type": "VLAHTTPPolicy",
+    "inputs": {
+      "observation": [
+        "3",
+        0
+      ],
+      "endpoint": "http://127.0.0.1:8787",
+      "timeout_seconds": 120.0,
+      "include_history": true,
+      "allow_remote": false
+    }
+  },
+  "5": {
+    "class_type": "VLAActionSafety",
+    "inputs": {
+      "actions": [
+        "4",
+        0
+      ],
+      "embodiment": [
+        "2",
+        0
+      ],
+      "mode": "Clamp safely",
+      "execution_horizon": 8,
+      "previous_action_json": "[0, 0, 0, 0, 0, 0, 0, 0]"
+    }
+  },
+  "6": {
+    "class_type": "VLATrajectoryPreview",
+    "inputs": {
+      "actions": [
+        "5",
+        0
+      ],
+      "width": 960,
+      "height": 480,
+      "embodiment": [
+        "2",
+        0
+      ]
+    }
+  },
+  "7": {
+    "class_type": "VLAActionInspect",
+    "inputs": {
+      "actions": [
+        "5",
+        0
+      ],
+      "step_index": 0
+    }
+  },
+  "8": {
+    "class_type": "PreviewImage",
+    "inputs": {
+      "images": [
+        "6",
+        0
+      ]
+    }
+  },
+  "9": {
+    "class_type": "ViewText",
+    "inputs": {
+      "text": [
+        "4",
+        1
+      ]
+    }
+  },
+  "10": {
+    "class_type": "ViewText",
+    "inputs": {
+      "text": [
+        "5",
+        1
+      ]
+    }
+  },
+  "11": {
+    "class_type": "ViewText",
+    "inputs": {
+      "text": [
+        "7",
+        0
+      ]
+    }
+  }
+}

--- a/nodes/robotics.py
+++ b/nodes/robotics.py
@@ -1,0 +1,2457 @@
+"""Dependency-isolated robotics/VLA workflow primitives.
+
+This module deliberately stops at the policy/safety boundary.  It prepares
+observations, calls an isolated policy server, validates returned action
+chunks, and visualizes them.  It never imports a robot SDK or sends commands
+to hardware.
+
+Heavy policy stacks (LeRobot, openpi, Isaac-GR00T, OpenVLA/OFT, and their
+accelerator-specific dependencies) belong in a separate environment.  The
+ComfyUI process remains portable and communicates through small, explicit
+client protocols.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import ipaddress
+import json
+import math
+import os
+import re
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+import numpy as np
+import torch
+from PIL import Image, ImageDraw
+
+from .runtime import require_module, tensor_to_pil
+
+VLA_EMBODIMENT = "VLA_EMBODIMENT"
+VLA_OBSERVATION = "VLA_OBSERVATION"
+VLA_ACTIONS = "VLA_ACTIONS"
+
+ROBOTICS_SCHEMA_VERSION = 1
+EMBODIMENT_SCHEMA = "comfyui-vlm/robot-embodiment"
+OBSERVATION_SCHEMA = "comfyui-vlm/robot-observation"
+ACTIONS_SCHEMA = "comfyui-vlm/robot-actions"
+
+MAX_TASK_CHARS = 16_384
+MAX_STATE_DIM = 2_048
+MAX_ACTION_DIM = 2_048
+MAX_ACTION_HORIZON = 4_096
+MAX_CAMERAS = 16
+MAX_HISTORY_FRAMES = 256
+MAX_IMAGE_PIXELS = 16 * 1024 * 1024
+MAX_HTTP_RESPONSE_BYTES = 32 * 1024 * 1024
+MAX_WIRE_IMAGE_BYTES = 8 * 1024 * 1024
+MAX_TOTAL_WIRE_IMAGE_BYTES = 45 * 1024 * 1024
+MAX_NATIVE_MESSAGE_BYTES = 128 * 1024 * 1024
+MAX_ERROR_CHARS = 1_000
+
+SAFETY_MODES = (
+    "Block unsafe",
+    "Clamp safely",
+    "Hold position on unsafe",
+    "Report only",
+)
+OPENPI_LAYOUTS = (
+    "Flat keys (DROID / LIBERO)",
+    "Nested images (ALOHA)",
+)
+TOKEN_ENV_BY_PROTOCOL = {
+    "http": "VLA_POLICY_TOKEN",
+    "openpi": "OPENPI_API_KEY",
+    "groot": "GROOT_API_TOKEN",
+}
+
+
+def _json(value: Any, *, indent: int | None = 2) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        indent=indent,
+        separators=None if indent is not None else (",", ":"),
+    )
+
+
+def _finite_float(value: Any, name: str) -> float:
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"{name} must be finite.")
+    return number
+
+
+def _finite_vector(
+    values: Sequence[Any],
+    *,
+    name: str,
+    expected: int | None = None,
+) -> tuple[float, ...]:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise TypeError(f"{name} must be a JSON array of numbers.")
+    result = tuple(_finite_float(value, f"{name}[{index}]") for index, value in enumerate(values))
+    if expected is not None and len(result) != expected:
+        raise ValueError(f"{name} must contain {expected} values, got {len(result)}.")
+    return result
+
+
+def _name_vector(
+    values: Sequence[Any],
+    *,
+    name: str,
+    maximum: int,
+) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise TypeError(f"{name} must be a JSON array of names.")
+    result = tuple(str(value).strip() for value in values)
+    if not result:
+        raise ValueError(f"{name} must not be empty.")
+    if len(result) > maximum:
+        raise ValueError(f"{name} exceeds the supported limit of {maximum}.")
+    if any(not value for value in result):
+        raise ValueError(f"{name} must not contain empty names.")
+    if len(set(result)) != len(result):
+        raise ValueError(f"{name} must not contain duplicate names.")
+    return result
+
+
+def _parse_json(value: str, *, name: str) -> Any:
+    try:
+        return json.loads((value or "").strip())
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"{name} is invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}."
+        ) from None
+
+
+def _optional_json_array(value: str, *, name: str) -> list[Any] | None:
+    raw = (value or "").strip()
+    if not raw:
+        return None
+    parsed = _parse_json(raw, name=name)
+    if not isinstance(parsed, list):
+        raise TypeError(f"{name} must be a JSON array.")
+    return parsed
+
+
+@dataclass(frozen=True, slots=True)
+class RobotEmbodiment:
+    """The action contract for one robot/policy pairing.
+
+    Presets are conservative workflow templates, not certified robot limits.
+    Real hardware deployments must replace them with limits from the robot
+    manufacturer and the trained policy's dataset metadata.
+    """
+
+    name: str
+    state_names: tuple[str, ...]
+    action_names: tuple[str, ...]
+    action_min: tuple[float, ...]
+    action_max: tuple[float, ...]
+    max_delta: tuple[float, ...]
+    control_hz: float
+    action_mode: str
+    camera_names: tuple[str, ...]
+    notes: str = ""
+
+    def __post_init__(self) -> None:
+        clean_name = str(self.name).strip()
+        if not clean_name:
+            raise ValueError("Embodiment name must not be empty.")
+        object.__setattr__(self, "name", clean_name)
+        object.__setattr__(
+            self,
+            "state_names",
+            _name_vector(self.state_names, name="state_names", maximum=MAX_STATE_DIM),
+        )
+        action_names = _name_vector(
+            self.action_names,
+            name="action_names",
+            maximum=MAX_ACTION_DIM,
+        )
+        object.__setattr__(self, "action_names", action_names)
+        action_min = _finite_vector(
+            self.action_min,
+            name="action_min",
+            expected=len(action_names),
+        )
+        action_max = _finite_vector(
+            self.action_max,
+            name="action_max",
+            expected=len(action_names),
+        )
+        max_delta = _finite_vector(
+            self.max_delta,
+            name="max_delta",
+            expected=len(action_names),
+        )
+        if any(low >= high for low, high in zip(action_min, action_max, strict=True)):
+            raise ValueError("Every action_min value must be smaller than action_max.")
+        if any(value <= 0 for value in max_delta):
+            raise ValueError("Every max_delta value must be positive.")
+        object.__setattr__(self, "action_min", action_min)
+        object.__setattr__(self, "action_max", action_max)
+        object.__setattr__(self, "max_delta", max_delta)
+        control_hz = _finite_float(self.control_hz, "control_hz")
+        if control_hz <= 0 or control_hz > 10_000:
+            raise ValueError("control_hz must be in the interval (0, 10000].")
+        object.__setattr__(self, "control_hz", control_hz)
+        action_mode = str(self.action_mode).strip()
+        if not action_mode:
+            raise ValueError("action_mode must not be empty.")
+        object.__setattr__(self, "action_mode", action_mode)
+        cameras = _name_vector(
+            self.camera_names,
+            name="camera_names",
+            maximum=MAX_CAMERAS,
+        )
+        object.__setattr__(self, "camera_names", cameras)
+        object.__setattr__(self, "notes", str(self.notes).strip())
+
+    @property
+    def action_dim(self) -> int:
+        return len(self.action_names)
+
+    @property
+    def state_dim(self) -> int:
+        return len(self.state_names)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": EMBODIMENT_SCHEMA,
+            "version": ROBOTICS_SCHEMA_VERSION,
+            "name": self.name,
+            "state_names": list(self.state_names),
+            "action_names": list(self.action_names),
+            "action_min": list(self.action_min),
+            "action_max": list(self.action_max),
+            "max_delta_per_step": list(self.max_delta),
+            "control_hz": self.control_hz,
+            "action_mode": self.action_mode,
+            "camera_names": list(self.camera_names),
+            "notes": self.notes,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> RobotEmbodiment:
+        if not isinstance(value, Mapping):
+            raise TypeError("An embodiment must be a JSON object.")
+        schema = value.get("schema")
+        if schema not in (None, EMBODIMENT_SCHEMA):
+            raise ValueError(f"Unsupported embodiment schema {schema!r}.")
+        version = int(value.get("version", ROBOTICS_SCHEMA_VERSION))
+        if version != ROBOTICS_SCHEMA_VERSION:
+            raise ValueError(f"Unsupported embodiment schema version {version}.")
+        return cls(
+            name=value["name"],
+            state_names=tuple(value["state_names"]),
+            action_names=tuple(value["action_names"]),
+            action_min=tuple(value["action_min"]),
+            action_max=tuple(value["action_max"]),
+            max_delta=tuple(value.get("max_delta_per_step", value.get("max_delta", ()))),
+            control_hz=value["control_hz"],
+            action_mode=value["action_mode"],
+            camera_names=tuple(value["camera_names"]),
+            notes=value.get("notes", ""),
+        )
+
+
+def _numbered_names(prefix: str, count: int) -> list[str]:
+    return [f"{prefix}_{index}" for index in range(count)]
+
+
+_EMBODIMENT_PRESET_SPECS: dict[str, dict[str, Any]] = {
+    "Generic 7-DoF joint + gripper": {
+        "name": "generic_7dof_joint_gripper",
+        "state_names": [*_numbered_names("joint", 7), "gripper"],
+        "action_names": [*_numbered_names("joint", 7), "gripper"],
+        "action_min": [-math.pi] * 7 + [0.0],
+        "action_max": [math.pi] * 7 + [1.0],
+        "max_delta": [0.12] * 7 + [0.15],
+        "control_hz": 20.0,
+        "action_mode": "absolute joint position",
+        "camera_names": ["observation.images.front"],
+    },
+    "Generic EEF delta + gripper": {
+        "name": "generic_eef_delta_gripper",
+        "state_names": ["x", "y", "z", "rx", "ry", "rz", "gripper"],
+        "action_names": ["dx", "dy", "dz", "drx", "dry", "drz", "gripper"],
+        "action_min": [-0.05, -0.05, -0.05, -0.25, -0.25, -0.25, -1.0],
+        "action_max": [0.05, 0.05, 0.05, 0.25, 0.25, 0.25, 1.0],
+        "max_delta": [0.025, 0.025, 0.025, 0.12, 0.12, 0.12, 0.5],
+        "control_hz": 20.0,
+        "action_mode": "delta end-effector pose",
+        "camera_names": ["observation.images.front", "observation.images.wrist"],
+    },
+    "LeRobot SO-100 / SO-101 template": {
+        "name": "lerobot_so100_so101_template",
+        "state_names": [
+            "shoulder_pan",
+            "shoulder_lift",
+            "elbow_flex",
+            "wrist_flex",
+            "wrist_roll",
+            "gripper",
+        ],
+        "action_names": [
+            "shoulder_pan",
+            "shoulder_lift",
+            "elbow_flex",
+            "wrist_flex",
+            "wrist_roll",
+            "gripper",
+        ],
+        "action_min": [-1.0] * 6,
+        "action_max": [1.0] * 6,
+        "max_delta": [0.10] * 5 + [0.15],
+        "control_hz": 30.0,
+        "action_mode": "dataset-normalized template",
+        "camera_names": ["observation.images.front", "observation.images.wrist"],
+    },
+    "LIBERO Panda simulation template": {
+        "name": "libero_panda_template",
+        "state_names": _numbered_names("state", 8),
+        "action_names": ["dx", "dy", "dz", "dax", "day", "daz", "gripper"],
+        "action_min": [-1.0] * 7,
+        "action_max": [1.0] * 7,
+        "max_delta": [0.25] * 6 + [1.0],
+        "control_hz": 20.0,
+        "action_mode": "LIBERO normalized delta template",
+        "camera_names": ["observation.image", "observation.wrist_image"],
+    },
+    "ALOHA bimanual template": {
+        "name": "aloha_bimanual_template",
+        "state_names": _numbered_names("joint", 14),
+        "action_names": _numbered_names("joint", 14),
+        "action_min": [-math.pi] * 14,
+        "action_max": [math.pi] * 14,
+        "max_delta": [0.12] * 14,
+        "control_hz": 50.0,
+        "action_mode": "absolute bimanual joint position",
+        "camera_names": ["cam_high", "cam_left_wrist", "cam_right_wrist"],
+    },
+}
+
+EMBODIMENT_PRESETS = tuple(_EMBODIMENT_PRESET_SPECS)
+_PRESET_WARNING = (
+    "Template limits are workflow defaults only. Replace them with the trained "
+    "checkpoint's dataset statistics and manufacturer/controller limits before deployment."
+)
+
+
+def make_embodiment(
+    preset: str,
+    *,
+    state_names: Sequence[Any] | None = None,
+    action_names: Sequence[Any] | None = None,
+    action_min: Sequence[Any] | None = None,
+    action_max: Sequence[Any] | None = None,
+    max_delta: Sequence[Any] | None = None,
+    control_hz: float | None = None,
+    camera_names: Sequence[Any] | None = None,
+    action_mode: str | None = None,
+) -> RobotEmbodiment:
+    try:
+        spec = dict(_EMBODIMENT_PRESET_SPECS[preset])
+    except KeyError:
+        raise ValueError(f"Unknown embodiment preset {preset!r}.") from None
+    overrides = {
+        "state_names": state_names,
+        "action_names": action_names,
+        "action_min": action_min,
+        "action_max": action_max,
+        "max_delta": max_delta,
+        "control_hz": control_hz,
+        "camera_names": camera_names,
+        "action_mode": action_mode,
+    }
+    spec.update({key: value for key, value in overrides.items() if value is not None})
+    spec["notes"] = _PRESET_WARNING
+    return RobotEmbodiment(**spec)
+
+
+def _canonical_image_batch(value: torch.Tensor, *, name: str) -> torch.Tensor:
+    if not isinstance(value, torch.Tensor):
+        raise TypeError(f"{name} must be a ComfyUI IMAGE tensor.")
+    image = value
+    if image.ndim == 3:
+        image = image.unsqueeze(0)
+    if image.ndim != 4:
+        raise ValueError(f"{name} must have HWC/BHWC or CHW/BCHW shape.")
+    if image.shape[-1] not in (1, 3, 4) and image.shape[1] in (1, 3, 4):
+        image = image.permute(0, 2, 3, 1)
+    if image.shape[-1] not in (1, 3, 4):
+        raise ValueError(f"{name} has unsupported channel shape {tuple(value.shape)}.")
+    if image.shape[0] < 1 or image.shape[0] > MAX_HISTORY_FRAMES:
+        raise ValueError(
+            f"{name} must contain 1 to {MAX_HISTORY_FRAMES} observation frames."
+        )
+    if image.shape[1] < 1 or image.shape[2] < 1:
+        raise ValueError(f"{name} contains an empty image.")
+    pixels = int(image.shape[1]) * int(image.shape[2])
+    if pixels > MAX_IMAGE_PIXELS:
+        raise ValueError(
+            f"{name} has {pixels} pixels per frame; limit is {MAX_IMAGE_PIXELS}. "
+            "Resize it with VLM Image Pixel Budget."
+        )
+    if not image.dtype.is_floating_point:
+        raise TypeError(f"{name} must use a floating-point ComfyUI IMAGE dtype.")
+    if not bool(torch.isfinite(image).all().item()):
+        raise ValueError(f"{name} contains NaN or infinite pixel values.")
+    return image
+
+
+@dataclass(frozen=True, slots=True)
+class RobotObservation:
+    task: str
+    state: tuple[float, ...]
+    images: tuple[tuple[str, torch.Tensor], ...]
+    timestamp: float
+    history_fps: float
+    metadata: tuple[tuple[str, Any], ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        task = str(self.task).strip()
+        if not task:
+            raise ValueError("Robot task/instruction must not be empty.")
+        if len(task) > MAX_TASK_CHARS:
+            raise ValueError(f"Robot task exceeds {MAX_TASK_CHARS} characters.")
+        object.__setattr__(self, "task", task)
+        state = _finite_vector(self.state, name="state")
+        if not state or len(state) > MAX_STATE_DIM:
+            raise ValueError(f"state must contain 1 to {MAX_STATE_DIM} values.")
+        object.__setattr__(self, "state", state)
+        images = tuple(self.images)
+        if not images or len(images) > MAX_CAMERAS:
+            raise ValueError(f"images must contain 1 to {MAX_CAMERAS} cameras.")
+        clean_images = []
+        for key, image in images:
+            clean_key = str(key).strip()
+            if not clean_key:
+                raise ValueError("Camera names must not be empty.")
+            clean_images.append((clean_key, _canonical_image_batch(image, name=clean_key)))
+        keys = [key for key, _image in clean_images]
+        if len(keys) != len(set(keys)):
+            raise ValueError("Camera names must be unique.")
+        frame_counts = {int(image.shape[0]) for _key, image in clean_images}
+        maximum = max(frame_counts)
+        if any(count not in {1, maximum} for count in frame_counts):
+            raise ValueError(
+                "Camera histories must have the same frame count; a one-frame "
+                "camera may broadcast across the longest history."
+            )
+        object.__setattr__(self, "images", tuple(clean_images))
+        timestamp = _finite_float(self.timestamp, "timestamp")
+        if timestamp < 0:
+            raise ValueError("timestamp must be non-negative.")
+        object.__setattr__(self, "timestamp", timestamp)
+        history_fps = _finite_float(self.history_fps, "history_fps")
+        if history_fps <= 0:
+            raise ValueError("history_fps must be positive.")
+        object.__setattr__(self, "history_fps", history_fps)
+        metadata = tuple((str(key), value) for key, value in self.metadata)
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def history_frames(self) -> int:
+        return max(int(image.shape[0]) for _key, image in self.images)
+
+    @property
+    def image_map(self) -> dict[str, torch.Tensor]:
+        return dict(self.images)
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "schema": OBSERVATION_SCHEMA,
+            "version": ROBOTICS_SCHEMA_VERSION,
+            "task": self.task,
+            "timestamp": self.timestamp,
+            "history_fps": self.history_fps,
+            "history_frames": self.history_frames,
+            "state": list(self.state),
+            "cameras": {
+                key: {
+                    "frames": int(image.shape[0]),
+                    "height": int(image.shape[1]),
+                    "width": int(image.shape[2]),
+                    "channels": int(image.shape[3]),
+                    "dtype": str(image.dtype),
+                    "device": str(image.device),
+                }
+                for key, image in self.images
+            },
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class RobotActions:
+    values: torch.Tensor
+    action_names: tuple[str, ...]
+    source: str
+    stream_slices: tuple[tuple[str, int, int], ...] = field(default_factory=tuple)
+    metadata: tuple[tuple[str, Any], ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.values, torch.Tensor):
+            raise TypeError("Action values must be a torch.Tensor.")
+        values = self.values.detach().to(device="cpu", dtype=torch.float32)
+        if values.ndim == 1:
+            values = values.unsqueeze(0)
+        if values.ndim != 2:
+            raise ValueError("Action values must have shape [horizon, action_dim].")
+        horizon, dimension = map(int, values.shape)
+        if not 1 <= horizon <= MAX_ACTION_HORIZON:
+            raise ValueError(f"Action horizon must be in [1, {MAX_ACTION_HORIZON}].")
+        if not 1 <= dimension <= MAX_ACTION_DIM:
+            raise ValueError(f"Action dimension must be in [1, {MAX_ACTION_DIM}].")
+        object.__setattr__(self, "values", values.contiguous())
+        names = tuple(str(name).strip() for name in self.action_names)
+        if len(names) != dimension or any(not name for name in names):
+            raise ValueError("action_names must contain one non-empty name per action dimension.")
+        object.__setattr__(self, "action_names", names)
+        object.__setattr__(self, "source", str(self.source).strip() or "unknown")
+        slices = tuple(self.stream_slices)
+        for stream, start, end in slices:
+            if not str(stream).strip() or not 0 <= int(start) < int(end) <= dimension:
+                raise ValueError("stream_slices contains an invalid range.")
+        object.__setattr__(self, "stream_slices", slices)
+        object.__setattr__(
+            self,
+            "metadata",
+            tuple((str(key), value) for key, value in self.metadata),
+        )
+
+    @property
+    def horizon(self) -> int:
+        return int(self.values.shape[0])
+
+    @property
+    def action_dim(self) -> int:
+        return int(self.values.shape[1])
+
+    def to_dict(self, *, include_values: bool = True) -> dict[str, Any]:
+        if include_values and not bool(torch.isfinite(self.values).all().item()):
+            raise ValueError(
+                "Action values contain NaN or infinity. Run VLA Action Safety "
+                "before serializing or executing this trajectory."
+            )
+        result: dict[str, Any] = {
+            "schema": ACTIONS_SCHEMA,
+            "version": ROBOTICS_SCHEMA_VERSION,
+            "source": self.source,
+            "horizon": self.horizon,
+            "action_dim": self.action_dim,
+            "action_names": list(self.action_names),
+            "streams": [
+                {"name": name, "start": start, "end": end}
+                for name, start, end in self.stream_slices
+            ],
+            "metadata": dict(self.metadata),
+        }
+        if include_values:
+            result["actions"] = self.values.tolist()
+        return result
+
+
+@dataclass(frozen=True, slots=True)
+class VLAModelInfo:
+    label: str
+    family: str
+    policy_type: str
+    checkpoint: str
+    backend: str
+    scale: str
+    status: str
+    best_for: str
+    license_note: str
+    official_url: str
+    notes: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "label": self.label,
+            "family": self.family,
+            "policy_type": self.policy_type,
+            "checkpoint": self.checkpoint,
+            "backend": self.backend,
+            "scale": self.scale,
+            "status": self.status,
+            "best_for": self.best_for,
+            "license_note": self.license_note,
+            "official_url": self.official_url,
+            "notes": self.notes,
+        }
+
+
+_MODEL_INFOS = (
+    VLAModelInfo(
+        "SmolVLA 450M — fast consumer hardware",
+        "SmolVLA",
+        "smolvla",
+        "lerobot/smolvla_base",
+        "LeRobot sidecar",
+        "450M",
+        "base; fine-tune for the target embodiment",
+        "small multi-camera manipulation and asynchronous control",
+        "Apache-2.0 code; verify checkpoint/model card",
+        "https://huggingface.co/lerobot/smolvla_base",
+        "The preferred small starting point. Do not send its base actions to "
+        "a robot without embodiment fine-tuning.",
+    ),
+    VLAModelInfo(
+        "X-VLA 0.9B — cross-embodiment",
+        "X-VLA",
+        "xvla",
+        "lerobot/xvla-base",
+        "LeRobot sidecar",
+        "0.9B",
+        "base plus deployable domain checkpoints",
+        "soft-prompt embodiment adaptation and multi-camera control",
+        "Apache-2.0 code; verify checkpoint/model card",
+        "https://huggingface.co/lerobot/xvla-base",
+        "Use a domain checkpoint such as xvla-libero/widowx/folding where it matches the task.",
+    ),
+    VLAModelInfo(
+        "π0 base — generalist VLA",
+        "π0",
+        "pi0",
+        "lerobot/pi0_base",
+        "LeRobot or openpi sidecar",
+        "large",
+        "base and LIBERO checkpoints",
+        "generalist manipulation and embodiment fine-tuning",
+        "Model terms vary; review the checkpoint",
+        "https://huggingface.co/lerobot/pi0_base",
+        "Use isolated inference; the upstream openpi runtime is primarily tested on Ubuntu.",
+    ),
+    VLAModelInfo(
+        "π0-FAST — tokenized fast actions",
+        "π0-FAST",
+        "pi0_fast",
+        "lerobot/pi0fast-base",
+        "LeRobot or openpi sidecar",
+        "large",
+        "base and LIBERO checkpoints",
+        "lower-latency autoregressive action generation",
+        "Model terms vary; review the checkpoint",
+        "https://huggingface.co/lerobot/pi0fast-base",
+        "FAST action tokenization is supported by current LeRobot and openpi runtimes.",
+    ),
+    VLAModelInfo(
+        "π0.5 base — open-world generalization",
+        "π0.5",
+        "pi05",
+        "lerobot/pi05_base",
+        "LeRobot or openpi sidecar",
+        "large",
+        "base and LIBERO checkpoints",
+        "language-conditioned manipulation and open-world tasks",
+        "Model terms vary; review the checkpoint",
+        "https://huggingface.co/lerobot/pi05_base",
+        "Requires an embodiment-compatible checkpoint and observation keys.",
+    ),
+    VLAModelInfo(
+        "GR00T N1.7 3B — cross-embodiment",
+        "Isaac GR00T N1.7",
+        "groot",
+        "nvidia/GR00T-N1.7-3B",
+        "GR00T ZMQ or LeRobot sidecar",
+        "3B",
+        "base plus DROID/LIBERO/SimplerEnv checkpoints",
+        "cross-embodiment manipulation and NVIDIA deployment",
+        "Apache-2.0 repository; verify checkpoint terms",
+        "https://huggingface.co/nvidia/GR00T-N1.7-3B",
+        "Use strict modality validation during development; action streams "
+        "are returned in physical units.",
+    ),
+    VLAModelInfo(
+        "WALL-OSS — mixture-of-experts VLA",
+        "WALL-OSS",
+        "wall_x",
+        "x-square-robot/wall-oss-flow",
+        "LeRobot sidecar",
+        "large MoE",
+        "pretrained flow checkpoint",
+        "general manipulation with flow/diffusion or FAST actions",
+        "Apache-2.0 integration; verify model card",
+        "https://huggingface.co/x-square-robot/wall-oss-flow",
+        "Fine-tune and validate on the target embodiment before use.",
+    ),
+    VLAModelInfo(
+        "MolmoAct2 — action reasoning",
+        "MolmoAct2",
+        "molmoact2",
+        "lerobot/MolmoAct2-SO100_101-LeRobot",
+        "LeRobot sidecar",
+        "large",
+        "converted SO-100/SO-101 checkpoint",
+        "robot action reasoning and SO-100/SO-101 experiments",
+        "Review AllenAI and checkpoint terms",
+        "https://huggingface.co/lerobot/MolmoAct2-SO100_101-LeRobot",
+        "The converted checkpoint uses the current LeRobot processor convention.",
+    ),
+    VLAModelInfo(
+        "VLA-JEPA — predictive world representation",
+        "VLA-JEPA",
+        "vla_jepa",
+        "lerobot/VLA-JEPA-Pretrain",
+        "LeRobot sidecar",
+        "research",
+        "DROID pretrain plus LIBERO/SimplerEnv checkpoints",
+        "multi-camera temporal prediction and representation learning",
+        "Verify original and converted checkpoint terms",
+        "https://huggingface.co/lerobot/VLA-JEPA-Pretrain",
+        "Action/state projection dimensions may need explicit reinitialization when fine-tuning.",
+    ),
+    VLAModelInfo(
+        "LingBot-VA — video-action model",
+        "LingBot-VA",
+        "lingbot_va",
+        "lerobot/lingbot_va_base",
+        "LeRobot sidecar",
+        "large",
+        "base plus LIBERO-Long and RoboTwin",
+        "long-horizon video-conditioned manipulation",
+        "Verify checkpoint/model card",
+        "https://huggingface.co/lerobot/lingbot_va_base",
+        "Select the post-trained domain checkpoint where available.",
+    ),
+    VLAModelInfo(
+        "FastWAM — world action model",
+        "FastWAM",
+        "fastwam",
+        "ZibinDong/fastwam_libero_uncond_2cam224",
+        "LeRobot sidecar",
+        "5B backbone class",
+        "released LIBERO research checkpoint",
+        "world-action modeling and video prediction research",
+        "Verify checkpoint and Wan component terms",
+        "https://huggingface.co/ZibinDong/fastwam_libero_uncond_2cam224",
+        "Heavy multi-component runtime; not a low-latency default.",
+    ),
+    VLAModelInfo(
+        "EO-1 — efficient VLA architecture",
+        "EO-1",
+        "eo1",
+        "",
+        "LeRobot sidecar",
+        "3B VLM class",
+        "architecture/training integration; supply your checkpoint",
+        "efficient action policy research",
+        "Verify backbone and checkpoint terms",
+        "https://huggingface.co/docs/lerobot/eo1",
+        "Current LeRobot integration documents training but does not prescribe "
+        "a universal robot-ready checkpoint.",
+    ),
+    VLAModelInfo(
+        "EVO-1 — embodied multimodal architecture",
+        "EVO-1",
+        "evo1",
+        "",
+        "LeRobot sidecar",
+        "research",
+        "architecture/training integration; supply your checkpoint",
+        "embodied multimodal policy research",
+        "Verify backbone and checkpoint terms",
+        "https://huggingface.co/docs/lerobot/evo1",
+        "Train or load an embodiment-specific LeRobot checkpoint.",
+    ),
+    VLAModelInfo(
+        "OpenVLA-OFT 7B — optimized OpenVLA",
+        "OpenVLA-OFT",
+        "openvla_oft",
+        "openvla/openvla-7b",
+        "dedicated OpenVLA/OFT sidecar",
+        "7B",
+        "base plus OFT fine-tunes",
+        "high-frequency multi-image OpenVLA deployment",
+        "MIT code; checkpoint/data terms vary",
+        "https://github.com/openvla/openvla",
+        "OFT is the recommended OpenVLA path for substantially faster action generation.",
+    ),
+    VLAModelInfo(
+        "Octo small 27M — legacy lightweight research",
+        "Octo",
+        "octo",
+        "hf://rail-berkeley/octo-small",
+        "dedicated JAX sidecar",
+        "27M",
+        "legacy research checkpoint",
+        "very small goal/language-conditioned research baseline",
+        "MIT code; verify checkpoint terms",
+        "https://github.com/octo-models/octo",
+        "Useful for research comparisons; the JAX stack is isolated from ComfyUI.",
+    ),
+)
+
+VLA_MODEL_CATALOG = {info.label: info for info in _MODEL_INFOS}
+VLA_MODEL_LABELS = tuple(VLA_MODEL_CATALOG)
+
+
+def _state_from_json(
+    value: str,
+    embodiment: RobotEmbodiment | None,
+) -> tuple[float, ...]:
+    parsed = _parse_json(value, name="state_json")
+    if isinstance(parsed, Mapping):
+        if embodiment is None:
+            raise ValueError(
+                "Object-form state_json requires an embodiment so key order is explicit."
+            )
+        missing = [name for name in embodiment.state_names if name not in parsed]
+        extras = [name for name in parsed if name not in embodiment.state_names]
+        if missing or extras:
+            raise ValueError(
+                f"State keys do not match embodiment. Missing={missing}, extra={extras}."
+            )
+        parsed = [parsed[name] for name in embodiment.state_names]
+    state = _finite_vector(parsed, name="state")
+    if embodiment is not None and len(state) != embodiment.state_dim:
+        raise ValueError(
+            f"State dimension {len(state)} does not match embodiment dimension "
+            f"{embodiment.state_dim}."
+        )
+    return state
+
+
+def _safe_camera_name(value: str, *, name: str) -> str:
+    result = str(value).strip()
+    if not result or len(result) > 256:
+        raise ValueError(f"{name} must contain 1 to 256 characters.")
+    if any(ord(char) < 32 for char in result):
+        raise ValueError(f"{name} contains a control character.")
+    return result
+
+
+def build_observation(
+    *,
+    task: str,
+    state_json: str,
+    primary_image: torch.Tensor,
+    primary_camera: str,
+    history_fps: float,
+    timestamp: float,
+    embodiment: RobotEmbodiment | None = None,
+    wrist_image: torch.Tensor | None = None,
+    wrist_camera: str = "observation.images.wrist",
+    secondary_image: torch.Tensor | None = None,
+    secondary_camera: str = "observation.images.secondary",
+    goal_image: torch.Tensor | None = None,
+    goal_camera: str = "observation.images.goal",
+) -> RobotObservation:
+    state = _state_from_json(state_json, embodiment)
+    images = [
+        (
+            _safe_camera_name(primary_camera, name="primary_camera"),
+            primary_image,
+        )
+    ]
+    for image, key, field_name in (
+        (wrist_image, wrist_camera, "wrist_camera"),
+        (secondary_image, secondary_camera, "secondary_camera"),
+        (goal_image, goal_camera, "goal_camera"),
+    ):
+        if image is not None:
+            images.append((_safe_camera_name(key, name=field_name), image))
+    observation = RobotObservation(
+        task=task,
+        state=state,
+        images=tuple(images),
+        timestamp=timestamp,
+        history_fps=history_fps,
+        metadata=(
+            ("embodiment", embodiment.name if embodiment else "unspecified"),
+            ("goal_conditioned", goal_image is not None),
+        ),
+    )
+    if embodiment is not None:
+        unknown = [key for key, _image in images if key not in embodiment.camera_names]
+        if unknown:
+            raise ValueError(
+                f"Camera names {unknown} are not declared by embodiment "
+                f"{embodiment.name!r}: {list(embodiment.camera_names)}."
+            )
+    return observation
+
+
+def _loopback_host(hostname: str | None) -> bool:
+    if not hostname:
+        return False
+    value = hostname.rstrip(".").lower()
+    if value == "localhost" or value.endswith(".localhost"):
+        return True
+    try:
+        return ipaddress.ip_address(value).is_loopback
+    except ValueError:
+        return False
+
+
+def validate_policy_url(value: str, *, allow_remote: bool) -> str:
+    raw = str(value or "").strip()
+    parsed = urlsplit(raw)
+    if parsed.scheme.lower() not in {"http", "https"} or not parsed.hostname:
+        raise ValueError("Policy endpoint must be an absolute HTTP(S) URL.")
+    if parsed.username or parsed.password:
+        raise ValueError("Policy endpoint must not contain embedded credentials.")
+    if parsed.query or parsed.fragment:
+        raise ValueError("Policy endpoint must not contain a query string or fragment.")
+    loopback = _loopback_host(parsed.hostname)
+    if parsed.scheme.lower() == "http" and not loopback:
+        raise ValueError("Remote policy endpoints must use HTTPS.")
+    if not loopback and not allow_remote:
+        raise ValueError(
+            "Remote policy access is disabled. Enable allow_remote only for a "
+            "trusted HTTPS policy server."
+        )
+    path = (parsed.path or "").rstrip("/")
+    if not path:
+        path = "/v1/infer"
+    elif not path.endswith("/v1/infer"):
+        path += "/v1/infer"
+    return urlunsplit((parsed.scheme.lower(), parsed.netloc, path, "", ""))
+
+
+def validate_ws_url(value: str, *, allow_remote: bool) -> str:
+    raw = str(value or "").strip()
+    if "://" not in raw:
+        raw = f"ws://{raw}"
+    parsed = urlsplit(raw)
+    if parsed.scheme.lower() not in {"ws", "wss"} or not parsed.hostname:
+        raise ValueError("OpenPI endpoint must be an absolute ws:// or wss:// URL.")
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise ValueError("OpenPI endpoint must not contain credentials, query, or fragment.")
+    loopback = _loopback_host(parsed.hostname)
+    if parsed.scheme.lower() == "ws" and not loopback:
+        raise ValueError("Remote OpenPI endpoints must use WSS.")
+    if not loopback and not allow_remote:
+        raise ValueError("Remote OpenPI access is disabled.")
+    return urlunsplit((parsed.scheme.lower(), parsed.netloc, parsed.path, "", ""))
+
+
+def validate_zmq_host(value: str, *, allow_remote: bool) -> str:
+    host = str(value or "").strip()
+    if not host or len(host) > 253:
+        raise ValueError("GR00T host is invalid.")
+    if "://" in host or any(char in host for char in "/?#@"):
+        raise ValueError("GR00T host must be a hostname or IP address only.")
+    if not _loopback_host(host) and not allow_remote:
+        raise ValueError("Remote GR00T access is disabled.")
+    return host
+
+
+def _redact(text: Any, secrets: Sequence[str] = ()) -> str:
+    result = str(text)
+    for secret in secrets:
+        if secret:
+            result = result.replace(secret, "[REDACTED]")
+    result = re.sub(
+        r"(?i)(authorization|api[-_ ]?key|token)\s*[:=]\s*\S+",
+        r"\1=[REDACTED]",
+        result,
+    )
+    return result[:MAX_ERROR_CHARS]
+
+
+def _image_png_payload(image: torch.Tensor) -> tuple[str, int]:
+    pil = tensor_to_pil(image)
+    buffer = io.BytesIO()
+    pil.save(buffer, format="JPEG", quality=92, optimize=True)
+    payload = buffer.getvalue()
+    if len(payload) > MAX_WIRE_IMAGE_BYTES:
+        raise ValueError(
+            f"Encoded observation image is {len(payload)} bytes; limit is "
+            f"{MAX_WIRE_IMAGE_BYTES}. Resize it with VLM Image Pixel Budget."
+        )
+    return base64.b64encode(payload).decode("ascii"), len(payload)
+
+
+def observation_to_http_payload(
+    observation: RobotObservation,
+    *,
+    include_history: bool,
+) -> dict[str, Any]:
+    total_bytes = 0
+    cameras = {}
+    for key, images in observation.images:
+        indices = range(int(images.shape[0])) if include_history else (int(images.shape[0]) - 1,)
+        frames = []
+        for index in indices:
+            encoded, byte_count = _image_png_payload(images[index])
+            total_bytes += byte_count
+            if total_bytes > MAX_TOTAL_WIRE_IMAGE_BYTES:
+                raise ValueError(
+                    "Encoded observation images exceed the total wire limit. "
+                    "Reduce history or pixels before policy inference."
+                )
+            frames.append(
+                {
+                    "encoding": "base64-jpeg",
+                    "data": encoded,
+                    "frame_index": int(index),
+                }
+            )
+        cameras[key] = frames
+    return {
+        "schema": OBSERVATION_SCHEMA,
+        "version": ROBOTICS_SCHEMA_VERSION,
+        "task": observation.task,
+        "state": list(observation.state),
+        "timestamp": observation.timestamp,
+        "history_fps": observation.history_fps,
+        "cameras": cameras,
+    }
+
+
+def _normalize_action_array(value: Any, *, name: str) -> torch.Tensor:
+    try:
+        tensor = torch.as_tensor(value, dtype=torch.float32, device="cpu")
+    except Exception as exc:
+        raise TypeError(f"Action stream {name!r} is not a numeric array.") from exc
+    if tensor.ndim == 3:
+        if tensor.shape[0] != 1:
+            raise ValueError(
+                f"Action stream {name!r} has batch size {tensor.shape[0]}; "
+                "ComfyUI robotics nodes currently require batch size 1."
+            )
+        tensor = tensor[0]
+    if tensor.ndim == 1:
+        tensor = tensor.unsqueeze(0)
+    if tensor.ndim != 2:
+        raise ValueError(
+            f"Action stream {name!r} must have [horizon, dim] or [1, horizon, dim] shape."
+        )
+    return tensor
+
+
+_ACTION_METADATA_KEYS = {
+    "info",
+    "metadata",
+    "server_timing",
+    "policy_timing",
+    "timing",
+    "latency_ms",
+}
+
+
+def actions_from_response(
+    response: Any,
+    *,
+    source: str,
+    action_names: Sequence[str] | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> RobotActions:
+    if (
+        isinstance(response, (list, tuple))
+        and len(response) == 2
+        and isinstance(response[0], Mapping)
+    ):
+        response = response[0]
+    if isinstance(response, Mapping):
+        for key in ("actions", "action"):
+            if key in response:
+                candidate = response[key]
+                break
+        else:
+            candidate = {
+                key: value
+                for key, value in response.items()
+                if key not in _ACTION_METADATA_KEYS
+            }
+    else:
+        candidate = response
+
+    slices: list[tuple[str, int, int]] = []
+    if isinstance(candidate, Mapping):
+        streams = []
+        offset = 0
+        horizon = None
+        for stream_name, stream_value in candidate.items():
+            tensor = _normalize_action_array(stream_value, name=str(stream_name))
+            if horizon is None:
+                horizon = int(tensor.shape[0])
+            elif int(tensor.shape[0]) != horizon:
+                raise ValueError("All action streams must have the same horizon.")
+            streams.append(tensor)
+            end = offset + int(tensor.shape[1])
+            slices.append((str(stream_name), offset, end))
+            offset = end
+        if not streams:
+            raise ValueError("Policy response contains no action streams.")
+        values = torch.cat(streams, dim=1)
+    else:
+        values = _normalize_action_array(candidate, name="actions")
+        slices = [("actions", 0, int(values.shape[1]))]
+
+    if action_names is None:
+        generated = []
+        for stream, start, end in slices:
+            generated.extend(f"{stream}[{index}]" for index in range(end - start))
+        names = tuple(generated)
+    else:
+        names = tuple(str(name) for name in action_names)
+    return RobotActions(
+        values=values,
+        action_names=names,
+        source=source,
+        stream_slices=tuple(slices),
+        metadata=tuple((str(key), value) for key, value in (metadata or {}).items()),
+    )
+
+
+def actions_from_json(value: str) -> RobotActions:
+    parsed = _parse_json(value, name="actions_json")
+    if isinstance(parsed, Mapping) and parsed.get("schema") == ACTIONS_SCHEMA:
+        version = int(parsed.get("version", 0))
+        if version != ROBOTICS_SCHEMA_VERSION:
+            raise ValueError(f"Unsupported robot-actions schema version {version}.")
+        names = parsed.get("action_names")
+        streams = tuple(
+            (str(item["name"]), int(item["start"]), int(item["end"]))
+            for item in parsed.get("streams", [])
+        )
+        result = actions_from_response(
+            parsed["actions"],
+            source=str(parsed.get("source", "json")),
+            action_names=names,
+            metadata=parsed.get("metadata", {}),
+        )
+        if streams:
+            result = RobotActions(
+                values=result.values,
+                action_names=result.action_names,
+                source=result.source,
+                stream_slices=streams,
+                metadata=result.metadata,
+            )
+        return result
+    return actions_from_response(parsed, source="json")
+
+
+def blend_action_chunks(
+    previous: RobotActions,
+    new: RobotActions,
+    *,
+    executed_steps: int,
+    transition_steps: int,
+    max_horizon: int,
+) -> tuple[RobotActions, dict[str, Any]]:
+    if not isinstance(previous, RobotActions) or not isinstance(new, RobotActions):
+        raise TypeError("previous and new must both be VLA action trajectories.")
+    if previous.action_dim != new.action_dim:
+        raise ValueError("Action chunk dimensions do not match.")
+    if previous.action_names != new.action_names:
+        raise ValueError("Action chunk names/order do not match.")
+    executed = int(executed_steps)
+    if not 0 <= executed <= previous.horizon:
+        raise ValueError("executed_steps is outside the previous action horizon.")
+    transition = int(transition_steps)
+    if transition < 0:
+        raise ValueError("transition_steps must be non-negative.")
+    horizon = int(max_horizon)
+    if not 1 <= horizon <= MAX_ACTION_HORIZON:
+        raise ValueError(f"max_horizon must be in [1, {MAX_ACTION_HORIZON}].")
+    output = new.values[:horizon].clone()
+    remaining = previous.values[executed:]
+    overlap = min(transition, int(remaining.shape[0]), int(output.shape[0]))
+    for index in range(overlap):
+        # Begin near the already-planned command and continuously hand control
+        # to the new plan. With one transition step, average the two.
+        alpha = (index + 1) / (overlap + 1)
+        output[index] = remaining[index] * (1.0 - alpha) + output[index] * alpha
+    blended = RobotActions(
+        values=output,
+        action_names=new.action_names,
+        source=f"replan:{new.source}",
+        stream_slices=new.stream_slices,
+        metadata=(
+            *new.metadata,
+            ("previous_source", previous.source),
+            ("executed_steps", executed),
+            ("transition_steps", overlap),
+        ),
+    )
+    report = {
+        "schema": "comfyui-vlm/robot-action-replan",
+        "version": ROBOTICS_SCHEMA_VERSION,
+        "previous_source": previous.source,
+        "new_source": new.source,
+        "previous_horizon": previous.horizon,
+        "new_horizon": new.horizon,
+        "executed_steps": executed,
+        "remaining_previous_steps": int(remaining.shape[0]),
+        "transition_steps_requested": transition,
+        "transition_steps_applied": overlap,
+        "output_horizon": blended.horizon,
+        "note": (
+            "Deterministic chunk-boundary smoothing only; it does not replace "
+            "a policy runtime's asynchronous or real-time chunking controller."
+        ),
+    }
+    return blended, report
+
+
+def call_http_policy(
+    observation: RobotObservation,
+    *,
+    endpoint: str,
+    timeout_seconds: float,
+    allow_remote: bool,
+    include_history: bool,
+) -> tuple[RobotActions, dict[str, Any]]:
+    url = validate_policy_url(endpoint, allow_remote=allow_remote)
+    timeout = _finite_float(timeout_seconds, "timeout_seconds")
+    if not 0.1 <= timeout <= 600:
+        raise ValueError("timeout_seconds must be between 0.1 and 600.")
+    token = os.environ.get(TOKEN_ENV_BY_PROTOCOL["http"], "").strip()
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "User-Agent": "ComfyUI-VLM-Nodes/robotics",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    payload = observation_to_http_payload(observation, include_history=include_history)
+    httpx = require_module("httpx")
+    started = time.perf_counter()
+    try:
+        with httpx.Client(
+            timeout=timeout,
+            follow_redirects=False,
+            trust_env=False,
+        ) as client, client.stream(
+            "POST",
+            url,
+            json=payload,
+            headers=headers,
+        ) as response:
+            response.raise_for_status()
+            declared_length = response.headers.get("content-length")
+            if (
+                declared_length is not None
+                and int(declared_length) > MAX_HTTP_RESPONSE_BYTES
+            ):
+                raise RuntimeError(
+                    "Policy response exceeds the 32 MiB safety limit."
+                )
+            content = bytearray()
+            for chunk in response.iter_bytes():
+                if len(content) + len(chunk) > MAX_HTTP_RESPONSE_BYTES:
+                    raise RuntimeError(
+                        "Policy response exceeds the 32 MiB safety limit."
+                    )
+                content.extend(chunk)
+            result = json.loads(content)
+    except Exception as exc:
+        raise RuntimeError(
+            f"Policy request failed: {_redact(exc, (token,))}"
+        ) from None
+    elapsed_ms = (time.perf_counter() - started) * 1000
+    names = result.get("action_names") if isinstance(result, Mapping) else None
+    actions = actions_from_response(
+        result,
+        source=f"http:{urlsplit(url).hostname}",
+        action_names=names,
+        metadata={"client_latency_ms": elapsed_ms},
+    )
+    report = {
+        "protocol": "comfyui-vla-http-v1",
+        "endpoint": f"{urlsplit(url).scheme}://{urlsplit(url).netloc}",
+        "client_latency_ms": elapsed_ms,
+        "horizon": actions.horizon,
+        "action_dim": actions.action_dim,
+        "history_sent": include_history,
+        "authenticated": bool(token),
+        "server_timing": _json_safe(
+            result.get("server_timing", {}) if isinstance(result, Mapping) else {}
+        ),
+        "policy": _json_safe(
+            result.get("policy", {}) if isinstance(result, Mapping) else {}
+        ),
+    }
+    return actions, report
+
+
+def _observation_image_uint8(
+    image: torch.Tensor,
+    *,
+    layout: str,
+) -> np.ndarray:
+    pil = tensor_to_pil(image, int(image.shape[0]) - 1)
+    array = np.asarray(pil, dtype=np.uint8)
+    if layout == "chw":
+        return np.ascontiguousarray(array.transpose(2, 0, 1))
+    return np.ascontiguousarray(array)
+
+
+def observation_to_openpi_payload(
+    observation: RobotObservation,
+    *,
+    layout: str,
+    state_key: str,
+    prompt_key: str,
+) -> dict[str, Any]:
+    clean_state_key = _safe_camera_name(state_key, name="state_key")
+    clean_prompt_key = _safe_camera_name(prompt_key, name="prompt_key")
+    if layout == "Nested images (ALOHA)":
+        return {
+            clean_state_key: np.asarray(observation.state, dtype=np.float32),
+            "images": {
+                key: _observation_image_uint8(image, layout="chw")
+                for key, image in observation.images
+            },
+            clean_prompt_key: observation.task,
+        }
+    if layout == "Flat keys (DROID / LIBERO)":
+        result: dict[str, Any] = {
+            clean_state_key: np.asarray(observation.state, dtype=np.float32),
+            clean_prompt_key: observation.task,
+        }
+        result.update(
+            {
+                key: _observation_image_uint8(image, layout="hwc")
+                for key, image in observation.images
+            }
+        )
+        return result
+    raise ValueError(f"Unknown OpenPI observation layout {layout!r}.")
+
+
+def _openpi_pack_array(value: Any) -> Any:
+    if (
+        isinstance(value, (np.ndarray, np.generic))
+        and value.dtype.kind in {"V", "O", "c"}
+    ):
+        raise ValueError(f"OpenPI protocol does not support dtype {value.dtype}.")
+    if isinstance(value, np.ndarray):
+        return {
+            b"__ndarray__": True,
+            b"data": value.tobytes(),
+            b"dtype": value.dtype.str,
+            b"shape": value.shape,
+        }
+    if isinstance(value, np.generic):
+        return {
+            b"__npgeneric__": True,
+            b"data": value.item(),
+            b"dtype": value.dtype.str,
+        }
+    raise TypeError(f"OpenPI protocol cannot encode {type(value).__name__}.")
+
+
+def _openpi_unpack_array(value: Any) -> Any:
+    if not isinstance(value, Mapping):
+        return value
+    if b"__ndarray__" in value or "__ndarray__" in value:
+        marker = b"__ndarray__" if b"__ndarray__" in value else "__ndarray__"
+        data_key = b"data" if b"data" in value else "data"
+        dtype_key = b"dtype" if b"dtype" in value else "dtype"
+        shape_key = b"shape" if b"shape" in value else "shape"
+        if not value.get(marker):
+            return value
+        dtype = np.dtype(value[dtype_key])
+        if dtype.kind in {"V", "O", "c"}:
+            raise ValueError(f"Refusing unsafe OpenPI response dtype {dtype}.")
+        shape = tuple(int(item) for item in value[shape_key])
+        if math.prod(shape) > MAX_ACTION_HORIZON * MAX_ACTION_DIM * 16:
+            raise ValueError("OpenPI response array exceeds the safety limit.")
+        return np.frombuffer(value[data_key], dtype=dtype).reshape(shape).copy()
+    if b"__npgeneric__" in value or "__npgeneric__" in value:
+        data_key = b"data" if b"data" in value else "data"
+        dtype_key = b"dtype" if b"dtype" in value else "dtype"
+        dtype = np.dtype(value[dtype_key])
+        if dtype.kind in {"V", "O", "c"}:
+            raise ValueError(f"Refusing unsafe OpenPI response dtype {dtype}.")
+        return dtype.type(value[data_key])
+    return value
+
+
+def call_openpi_policy(
+    observation: RobotObservation,
+    *,
+    endpoint: str,
+    timeout_seconds: float,
+    allow_remote: bool,
+    layout: str,
+    state_key: str,
+    prompt_key: str,
+) -> tuple[RobotActions, dict[str, Any]]:
+    uri = validate_ws_url(endpoint, allow_remote=allow_remote)
+    timeout = _finite_float(timeout_seconds, "timeout_seconds")
+    if not 0.1 <= timeout <= 600:
+        raise ValueError("timeout_seconds must be between 0.1 and 600.")
+    websockets = require_module("websockets.sync.client", "websockets")
+    msgpack = require_module("msgpack")
+    token = os.environ.get(TOKEN_ENV_BY_PROTOCOL["openpi"], "").strip()
+    headers = {"Authorization": f"Api-Key {token}"} if token else None
+    payload = observation_to_openpi_payload(
+        observation,
+        layout=layout,
+        state_key=state_key,
+        prompt_key=prompt_key,
+    )
+    started = time.perf_counter()
+    try:
+        with websockets.connect(
+            uri,
+            compression=None,
+            max_size=MAX_HTTP_RESPONSE_BYTES,
+            additional_headers=headers,
+            open_timeout=timeout,
+            close_timeout=min(timeout, 10.0),
+        ) as connection:
+            metadata_bytes = connection.recv(timeout=timeout)
+            if isinstance(metadata_bytes, str):
+                raise RuntimeError("OpenPI metadata response must be binary MessagePack.")
+            server_metadata = msgpack.unpackb(
+                metadata_bytes,
+                object_hook=_openpi_unpack_array,
+            )
+            request = msgpack.packb(payload, default=_openpi_pack_array)
+            connection.send(request)
+            response_bytes = connection.recv(timeout=timeout)
+            if isinstance(response_bytes, str):
+                raise RuntimeError(_redact(response_bytes, (token,)))
+            result = msgpack.unpackb(
+                response_bytes,
+                object_hook=_openpi_unpack_array,
+            )
+    except Exception as exc:
+        raise RuntimeError(
+            f"OpenPI request failed: {_redact(exc, (token,))}"
+        ) from None
+    elapsed_ms = (time.perf_counter() - started) * 1000
+    actions = actions_from_response(
+        result,
+        source=f"openpi:{urlsplit(uri).hostname}",
+        metadata={"client_latency_ms": elapsed_ms},
+    )
+    report = {
+        "protocol": "openpi-websocket",
+        "endpoint": f"{urlsplit(uri).scheme}://{urlsplit(uri).netloc}",
+        "client_latency_ms": elapsed_ms,
+        "horizon": actions.horizon,
+        "action_dim": actions.action_dim,
+        "authenticated": bool(token),
+        "server_metadata": _json_safe(server_metadata),
+        "server_timing": _json_safe(
+            result.get("server_timing", {}) if isinstance(result, Mapping) else {}
+        ),
+    }
+    return actions, report
+
+
+def _groot_encode(value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        if value.dtype.kind in {"O", "V"}:
+            raise TypeError("Refusing object/void ndarray in GR00T request.")
+        if value.dtype.kind == "c":
+            return {
+                b"nd": True,
+                b"type": value.dtype.str,
+                b"kind": b"c",
+                b"shape": value.shape,
+                b"real": value.real.tobytes(),
+                b"imag": value.imag.tobytes(),
+            }
+        return {
+            b"nd": True,
+            b"type": value.dtype.str,
+            b"kind": value.dtype.kind.encode(),
+            b"shape": value.shape,
+            b"data": value.tobytes(),
+        }
+    if isinstance(value, np.generic):
+        return {
+            b"nd": False,
+            b"type": value.dtype.str,
+            b"data": value.item(),
+        }
+    raise TypeError(f"GR00T protocol cannot encode {type(value).__name__}.")
+
+
+def _groot_decode(value: Any) -> Any:
+    if not isinstance(value, Mapping):
+        return value
+    nd = value.get(b"nd", value.get("nd"))
+    if nd is None:
+        return value
+    kind = value.get(b"kind", value.get("kind"))
+    if kind in (b"O", "O", b"V", "V"):
+        raise ValueError("Refusing object/void ndarray in GR00T response.")
+    dtype_value = value.get(b"type", value.get("type"))
+    data = value.get(b"data", value.get("data"))
+    dtype = np.dtype(dtype_value)
+    if nd:
+        shape = tuple(int(item) for item in value.get(b"shape", value.get("shape")))
+        if math.prod(shape) > MAX_ACTION_HORIZON * MAX_ACTION_DIM * 16:
+            raise ValueError("GR00T response array exceeds the safety limit.")
+        return np.frombuffer(data, dtype=dtype).reshape(shape).copy()
+    return dtype.type(data)
+
+
+def observation_to_groot_payload(observation: RobotObservation) -> dict[str, Any]:
+    history = observation.history_frames
+    video = {}
+    total_bytes = 0
+    for key, images in observation.images:
+        frames = images
+        if int(frames.shape[0]) == 1 and history > 1:
+            frames = frames.expand(history, *frames.shape[1:])
+        arrays = [
+            np.asarray(tensor_to_pil(frames, index), dtype=np.uint8)
+            for index in range(int(frames.shape[0]))
+        ]
+        camera = np.ascontiguousarray(np.stack(arrays, axis=0)[None, ...])
+        total_bytes += int(camera.nbytes)
+        if total_bytes > MAX_NATIVE_MESSAGE_BYTES:
+            raise ValueError(
+                "GR00T observation images exceed the 128 MiB message limit. "
+                "Reduce history or pixels before policy inference."
+            )
+        video[key] = camera
+    state = np.asarray(observation.state, dtype=np.float32)
+    state = np.broadcast_to(state, (1, history, len(state))).copy()
+    return {
+        "video": video,
+        "state": {"state": state},
+        "language": {"task": [[observation.task]]},
+    }
+
+
+def call_groot_policy(
+    observation: RobotObservation,
+    *,
+    host: str,
+    port: int,
+    timeout_seconds: float,
+    allow_remote: bool,
+) -> tuple[RobotActions, dict[str, Any]]:
+    clean_host = validate_zmq_host(host, allow_remote=allow_remote)
+    clean_port = int(port)
+    if not 1 <= clean_port <= 65_535:
+        raise ValueError("GR00T port must be in [1, 65535].")
+    timeout = _finite_float(timeout_seconds, "timeout_seconds")
+    if not 0.1 <= timeout <= 600:
+        raise ValueError("timeout_seconds must be between 0.1 and 600.")
+    zmq = require_module("zmq", "pyzmq")
+    msgpack = require_module("msgpack")
+    token = os.environ.get(TOKEN_ENV_BY_PROTOCOL["groot"], "").strip()
+    request = {
+        "endpoint": "get_action",
+        "data": {
+            "observation": observation_to_groot_payload(observation),
+            "options": None,
+        },
+    }
+    if token:
+        request["api_token"] = token
+    context = zmq.Context()
+    socket = context.socket(zmq.REQ)
+    timeout_ms = int(timeout * 1000)
+    socket.setsockopt(zmq.RCVTIMEO, timeout_ms)
+    socket.setsockopt(zmq.SNDTIMEO, timeout_ms)
+    socket.setsockopt(zmq.LINGER, 0)
+    if hasattr(zmq, "MAXMSGSIZE"):
+        socket.setsockopt(zmq.MAXMSGSIZE, MAX_HTTP_RESPONSE_BYTES)
+    started = time.perf_counter()
+    try:
+        socket.connect(f"tcp://{clean_host}:{clean_port}")
+        request_bytes = msgpack.packb(request, default=_groot_encode)
+        if len(request_bytes) > MAX_NATIVE_MESSAGE_BYTES:
+            raise ValueError("GR00T request exceeds the 128 MiB message limit.")
+        socket.send(request_bytes)
+        response_bytes = socket.recv()
+        if len(response_bytes) > MAX_HTTP_RESPONSE_BYTES:
+            raise RuntimeError("GR00T response exceeds the 32 MiB safety limit.")
+        result = msgpack.unpackb(
+            response_bytes,
+            object_hook=_groot_decode,
+            raw=False,
+        )
+        if isinstance(result, Mapping) and "error" in result:
+            raise RuntimeError(result["error"])
+    except Exception as exc:
+        raise RuntimeError(
+            f"GR00T request failed: {_redact(exc, (token,))}"
+        ) from None
+    finally:
+        socket.close(linger=0)
+        context.term()
+    elapsed_ms = (time.perf_counter() - started) * 1000
+    info = result[1] if isinstance(result, (list, tuple)) and len(result) > 1 else {}
+    actions = actions_from_response(
+        result,
+        source=f"groot:{clean_host}",
+        metadata={"client_latency_ms": elapsed_ms},
+    )
+    report = {
+        "protocol": "isaac-groot-zmq",
+        "endpoint": f"tcp://{clean_host}:{clean_port}",
+        "client_latency_ms": elapsed_ms,
+        "horizon": actions.horizon,
+        "action_dim": actions.action_dim,
+        "authenticated": bool(token),
+        "policy_info": _json_safe(info),
+    }
+    return actions, report
+
+
+def _json_safe(value: Any) -> Any:
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else str(value)
+    if isinstance(value, np.generic):
+        return _json_safe(value.item())
+    if isinstance(value, np.ndarray):
+        if value.size > 1024:
+            return {
+                "shape": list(value.shape),
+                "dtype": str(value.dtype),
+                "omitted": True,
+            }
+        return _json_safe(value.tolist())
+    if isinstance(value, torch.Tensor):
+        if value.numel() > 1024:
+            return {
+                "shape": list(value.shape),
+                "dtype": str(value.dtype),
+                "omitted": True,
+            }
+        return _json_safe(value.detach().cpu().tolist())
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    return str(value)
+
+
+def _previous_action(
+    value: str,
+    *,
+    dimension: int,
+) -> torch.Tensor | None:
+    raw = (value or "").strip()
+    if not raw:
+        return None
+    parsed = _parse_json(raw, name="previous_action_json")
+    vector = _finite_vector(parsed, name="previous_action", expected=dimension)
+    return torch.tensor(vector, dtype=torch.float32)
+
+
+def validate_action_trajectory(
+    actions: RobotActions,
+    embodiment: RobotEmbodiment,
+    *,
+    mode: str,
+    execution_horizon: int,
+    previous_action_json: str = "",
+) -> tuple[RobotActions, dict[str, Any]]:
+    if not isinstance(actions, RobotActions):
+        raise TypeError("actions must be a VLA action trajectory.")
+    if not isinstance(embodiment, RobotEmbodiment):
+        raise TypeError("embodiment must be a VLA embodiment profile.")
+    if mode not in SAFETY_MODES:
+        raise ValueError(f"Unknown action safety mode {mode!r}.")
+    if actions.action_dim != embodiment.action_dim:
+        raise ValueError(
+            f"Policy returned {actions.action_dim} action values, but embodiment "
+            f"{embodiment.name!r} requires {embodiment.action_dim}."
+        )
+    horizon = int(execution_horizon)
+    if horizon < 1:
+        raise ValueError("execution_horizon must be at least 1.")
+    horizon = min(horizon, actions.horizon)
+    original = actions.values[:horizon].clone()
+    result = original.clone()
+    low = torch.tensor(embodiment.action_min, dtype=torch.float32)
+    high = torch.tensor(embodiment.action_max, dtype=torch.float32)
+    delta_limit = torch.tensor(embodiment.max_delta, dtype=torch.float32)
+    previous = _previous_action(
+        previous_action_json,
+        dimension=embodiment.action_dim,
+    )
+
+    finite_mask = torch.isfinite(original)
+    nonfinite_count = int((~finite_mask).sum().item())
+    fallback = previous if previous is not None else (low + high) * 0.5
+    result = torch.where(finite_mask, result, fallback.unsqueeze(0))
+    below = result < low
+    above = result > high
+    bounds_count = int((below | above).sum().item())
+
+    delta_count = 0
+    running_previous = previous
+    for index in range(horizon):
+        if running_previous is not None:
+            delta = result[index] - running_previous
+            delta_count += int((delta.abs() > delta_limit).sum().item())
+        running_previous = result[index]
+    violation_count = nonfinite_count + bounds_count + delta_count
+
+    if violation_count and mode == "Block unsafe":
+        raise ValueError(
+            "Unsafe policy action blocked: "
+            f"{nonfinite_count} non-finite, {bounds_count} bounds, "
+            f"{delta_count} per-step delta violations."
+        )
+    if violation_count and mode == "Hold position on unsafe":
+        if previous is None:
+            raise ValueError(
+                "Hold position on unsafe requires previous_action_json with one "
+                "current/commanded value per action dimension."
+            )
+        result = previous.unsqueeze(0).expand(horizon, -1).clone()
+    elif mode == "Clamp safely":
+        result = torch.maximum(torch.minimum(result, high), low)
+        running_previous = previous
+        for index in range(horizon):
+            if running_previous is not None:
+                result[index] = torch.maximum(
+                    torch.minimum(result[index], running_previous + delta_limit),
+                    running_previous - delta_limit,
+                )
+                result[index] = torch.maximum(torch.minimum(result[index], high), low)
+            running_previous = result[index].clone()
+    elif mode == "Report only":
+        result = original
+
+    changed = not torch.equal(result, original)
+    finite_after = bool(torch.isfinite(result).all().item())
+    in_bounds_after = (
+        bool(((result >= low) & (result <= high)).all().item())
+        if finite_after
+        else False
+    )
+    safe_after = finite_after and in_bounds_after
+    if safe_after:
+        running_previous = previous
+        for index in range(horizon):
+            if running_previous is not None and bool(
+                ((result[index] - running_previous).abs() > delta_limit).any().item()
+            ):
+                safe_after = False
+                break
+            running_previous = result[index]
+    validated = RobotActions(
+        values=result,
+        action_names=embodiment.action_names,
+        source=actions.source,
+        stream_slices=actions.stream_slices,
+        metadata=(
+            *actions.metadata,
+            ("safety_mode", mode),
+            ("embodiment", embodiment.name),
+            ("validated", safe_after),
+        ),
+    )
+    report = {
+        "schema": "comfyui-vlm/robot-action-safety",
+        "version": ROBOTICS_SCHEMA_VERSION,
+        "embodiment": embodiment.name,
+        "action_mode": embodiment.action_mode,
+        "policy_source": actions.source,
+        "input_horizon": actions.horizon,
+        "execution_horizon": horizon,
+        "action_dim": actions.action_dim,
+        "mode": mode,
+        "previous_action_provided": previous is not None,
+        "violations": {
+            "non_finite_values": nonfinite_count,
+            "out_of_bounds_values": bounds_count,
+            "per_step_delta_values": delta_count,
+            "total": violation_count,
+        },
+        "changed": changed,
+        "safe_for_handoff": safe_after,
+        "warning": (
+            "This is a workflow safety gate, not a certified robot safety "
+            "controller. A hardware deadman, watchdog, collision limits, and "
+            "manufacturer controller remain mandatory."
+        ),
+    }
+    return validated, report
+
+
+def render_action_preview(
+    actions: RobotActions,
+    *,
+    embodiment: RobotEmbodiment | None = None,
+    width: int = 960,
+    height: int = 480,
+) -> torch.Tensor:
+    width = int(width)
+    height = int(height)
+    if width < 320 or height < 240:
+        raise ValueError("Preview dimensions must be at least 320x240.")
+    canvas = Image.new("RGB", (width, height), (18, 21, 28))
+    draw = ImageDraw.Draw(canvas)
+    margin_left, margin_right, margin_top, margin_bottom = 72, 24, 42, 48
+    chart_width = width - margin_left - margin_right
+    chart_height = height - margin_top - margin_bottom
+    values = actions.values
+    finite = torch.isfinite(values)
+    plot_values = torch.where(finite, values, torch.zeros_like(values))
+    if embodiment is not None and embodiment.action_dim == actions.action_dim:
+        global_low = min(embodiment.action_min)
+        global_high = max(embodiment.action_max)
+    else:
+        global_low = float(plot_values.min().item())
+        global_high = float(plot_values.max().item())
+        if math.isclose(global_low, global_high):
+            global_low -= 1.0
+            global_high += 1.0
+    span = max(global_high - global_low, 1.0e-6)
+    draw.text(
+        (margin_left, 14),
+        f"{actions.source} — {actions.horizon} × {actions.action_dim}",
+        fill=(235, 238, 245),
+    )
+    draw.rectangle(
+        (
+            margin_left,
+            margin_top,
+            margin_left + chart_width,
+            margin_top + chart_height,
+        ),
+        outline=(87, 94, 111),
+        width=1,
+    )
+    for tick in range(5):
+        y = margin_top + round(chart_height * tick / 4)
+        value = global_high - span * tick / 4
+        draw.line((margin_left, y, margin_left + chart_width, y), fill=(47, 53, 65))
+        draw.text((6, y - 7), f"{value:.3g}", fill=(165, 171, 184))
+    palette = (
+        (96, 165, 250),
+        (244, 114, 182),
+        (52, 211, 153),
+        (251, 191, 36),
+        (167, 139, 250),
+        (248, 113, 113),
+        (34, 211, 238),
+        (163, 230, 53),
+    )
+    for dimension in range(actions.action_dim):
+        color = palette[dimension % len(palette)]
+        points = []
+        for step in range(actions.horizon):
+            x = (
+                margin_left + chart_width // 2
+                if actions.horizon == 1
+                else margin_left + round(chart_width * step / (actions.horizon - 1))
+            )
+            y = margin_top + round(
+                chart_height
+                * (global_high - float(plot_values[step, dimension].item()))
+                / span
+            )
+            points.append((x, y))
+        if len(points) > 1:
+            draw.line(points, fill=color, width=2)
+        else:
+            x, y = points[0]
+            draw.ellipse((x - 3, y - 3, x + 3, y + 3), fill=color)
+    if not bool(finite.all().item()):
+        draw.text(
+            (margin_left, height - 28),
+            "WARNING: raw trajectory contains NaN or infinity",
+            fill=(248, 113, 113),
+        )
+    else:
+        draw.text(
+            (margin_left, height - 28),
+            "Preview only — validate with VLA Action Safety before controller handoff",
+            fill=(165, 171, 184),
+        )
+    array = np.asarray(canvas, dtype=np.float32) / 255.0
+    return torch.from_numpy(array.copy()).unsqueeze(0)
+
+
+class VLAEmbodimentProfile:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "preset": (EMBODIMENT_PRESETS, {"default": EMBODIMENT_PRESETS[0]}),
+                "control_hz": (
+                    "FLOAT",
+                    {"default": 0.0, "min": 0.0, "max": 10_000.0, "step": 1.0},
+                ),
+                "state_names_json": (
+                    "STRING",
+                    {"default": "", "multiline": True, "dynamicPrompts": False},
+                ),
+                "action_names_json": (
+                    "STRING",
+                    {"default": "", "multiline": True, "dynamicPrompts": False},
+                ),
+                "action_min_json": (
+                    "STRING",
+                    {"default": "", "multiline": True, "dynamicPrompts": False},
+                ),
+                "action_max_json": (
+                    "STRING",
+                    {"default": "", "multiline": True, "dynamicPrompts": False},
+                ),
+                "max_delta_json": (
+                    "STRING",
+                    {"default": "", "multiline": True, "dynamicPrompts": False},
+                ),
+                "camera_names_json": (
+                    "STRING",
+                    {"default": "", "multiline": True, "dynamicPrompts": False},
+                ),
+                "action_mode_override": (
+                    "STRING",
+                    {"default": "", "multiline": False, "dynamicPrompts": False},
+                ),
+            }
+        }
+
+    RETURN_TYPES = (VLA_EMBODIMENT, "STRING", "INT", "INT")
+    RETURN_NAMES = ("embodiment", "profile_json", "state_dim", "action_dim")
+    FUNCTION = "build"
+    CATEGORY = "VLM Nodes/Robotics/Schemas"
+    DESCRIPTION = (
+        "Create an explicit robot state/action/camera contract. Presets are "
+        "templates; override their bounds with controller-approved limits."
+    )
+
+    def build(
+        self,
+        preset,
+        control_hz,
+        state_names_json,
+        action_names_json,
+        action_min_json,
+        action_max_json,
+        max_delta_json,
+        camera_names_json,
+        action_mode_override,
+    ):
+        profile = make_embodiment(
+            preset,
+            state_names=_optional_json_array(state_names_json, name="state_names_json"),
+            action_names=_optional_json_array(action_names_json, name="action_names_json"),
+            action_min=_optional_json_array(action_min_json, name="action_min_json"),
+            action_max=_optional_json_array(action_max_json, name="action_max_json"),
+            max_delta=_optional_json_array(max_delta_json, name="max_delta_json"),
+            control_hz=float(control_hz) if float(control_hz) > 0 else None,
+            camera_names=_optional_json_array(camera_names_json, name="camera_names_json"),
+            action_mode=(action_mode_override or "").strip() or None,
+        )
+        return profile, _json(profile.to_dict()), profile.state_dim, profile.action_dim
+
+
+class VLAObservationBuilder:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "task": (
+                    "STRING",
+                    {
+                        "default": "Pick up the object and place it in the container.",
+                        "multiline": True,
+                        "dynamicPrompts": False,
+                    },
+                ),
+                "state_json": (
+                    "STRING",
+                    {
+                        "default": "[0, 0, 0, 0, 0, 0, 0, 0]",
+                        "multiline": True,
+                        "dynamicPrompts": False,
+                    },
+                ),
+                "primary_image": ("IMAGE",),
+                "primary_camera": (
+                    "STRING",
+                    {"default": "observation.images.front", "dynamicPrompts": False},
+                ),
+                "history_fps": (
+                    "FLOAT",
+                    {"default": 10.0, "min": 0.01, "max": 1_000.0, "step": 0.1},
+                ),
+                "timestamp": (
+                    "FLOAT",
+                    {"default": 0.0, "min": 0.0, "max": 1.0e12, "step": 0.001},
+                ),
+            },
+            "optional": {
+                "embodiment": (VLA_EMBODIMENT,),
+                "wrist_image": ("IMAGE",),
+                "wrist_camera": (
+                    "STRING",
+                    {"default": "observation.images.wrist", "dynamicPrompts": False},
+                ),
+                "secondary_image": ("IMAGE",),
+                "secondary_camera": (
+                    "STRING",
+                    {"default": "observation.images.secondary", "dynamicPrompts": False},
+                ),
+                "goal_image": ("IMAGE",),
+                "goal_camera": (
+                    "STRING",
+                    {"default": "observation.images.goal", "dynamicPrompts": False},
+                ),
+            },
+        }
+
+    RETURN_TYPES = (VLA_OBSERVATION, "STRING", "INT")
+    RETURN_NAMES = ("observation", "observation_summary", "history_frames")
+    FUNCTION = "build"
+    CATEGORY = "VLM Nodes/Robotics/Observations"
+    DESCRIPTION = (
+        "Build one validated language + state + multi-camera observation. "
+        "IMAGE batches become temporal history; no policy or robot SDK is loaded."
+    )
+
+    def build(
+        self,
+        task,
+        state_json,
+        primary_image,
+        primary_camera,
+        history_fps,
+        timestamp,
+        embodiment=None,
+        wrist_image=None,
+        wrist_camera="observation.images.wrist",
+        secondary_image=None,
+        secondary_camera="observation.images.secondary",
+        goal_image=None,
+        goal_camera="observation.images.goal",
+    ):
+        observation = build_observation(
+            task=task,
+            state_json=state_json,
+            primary_image=primary_image,
+            primary_camera=primary_camera,
+            history_fps=history_fps,
+            timestamp=timestamp,
+            embodiment=embodiment,
+            wrist_image=wrist_image,
+            wrist_camera=wrist_camera,
+            secondary_image=secondary_image,
+            secondary_camera=secondary_camera,
+            goal_image=goal_image,
+            goal_camera=goal_camera,
+        )
+        return observation, _json(observation.summary()), observation.history_frames
+
+
+class VLAHTTPPolicy:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "observation": (VLA_OBSERVATION,),
+                "endpoint": (
+                    "STRING",
+                    {"default": "http://127.0.0.1:8787", "dynamicPrompts": False},
+                ),
+                "timeout_seconds": (
+                    "FLOAT",
+                    {"default": 120.0, "min": 0.1, "max": 600.0, "step": 1.0},
+                ),
+                "include_history": ("BOOLEAN", {"default": True}),
+                "allow_remote": ("BOOLEAN", {"default": False}),
+            }
+        }
+
+    RETURN_TYPES = (VLA_ACTIONS, "STRING")
+    RETURN_NAMES = ("actions", "inference_report")
+    FUNCTION = "infer"
+    CATEGORY = "VLM Nodes/Robotics/Policies"
+    DESCRIPTION = (
+        "Call the isolated universal VLA HTTP sidecar. Remote servers require "
+        "HTTPS and explicit opt-in. VLA_POLICY_TOKEN stays server-side."
+    )
+
+    def infer(
+        self,
+        observation,
+        endpoint,
+        timeout_seconds,
+        include_history,
+        allow_remote,
+    ):
+        actions, report = call_http_policy(
+            observation,
+            endpoint=endpoint,
+            timeout_seconds=timeout_seconds,
+            allow_remote=allow_remote,
+            include_history=include_history,
+        )
+        return actions, _json(report)
+
+
+class VLAOpenPIWebSocketPolicy:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "observation": (VLA_OBSERVATION,),
+                "endpoint": (
+                    "STRING",
+                    {"default": "ws://127.0.0.1:8000", "dynamicPrompts": False},
+                ),
+                "observation_layout": (
+                    OPENPI_LAYOUTS,
+                    {"default": OPENPI_LAYOUTS[0]},
+                ),
+                "state_key": (
+                    "STRING",
+                    {"default": "observation/state", "dynamicPrompts": False},
+                ),
+                "prompt_key": (
+                    "STRING",
+                    {"default": "prompt", "dynamicPrompts": False},
+                ),
+                "timeout_seconds": (
+                    "FLOAT",
+                    {"default": 120.0, "min": 0.1, "max": 600.0, "step": 1.0},
+                ),
+                "allow_remote": ("BOOLEAN", {"default": False}),
+            }
+        }
+
+    RETURN_TYPES = (VLA_ACTIONS, "STRING")
+    RETURN_NAMES = ("actions", "inference_report")
+    FUNCTION = "infer"
+    CATEGORY = "VLM Nodes/Robotics/Policies"
+    DESCRIPTION = (
+        "Native client for the official openpi MessagePack WebSocket server. "
+        "Install the lightweight robotics client extra; OPENPI_API_KEY is "
+        "never stored in workflows."
+    )
+
+    def infer(
+        self,
+        observation,
+        endpoint,
+        observation_layout,
+        state_key,
+        prompt_key,
+        timeout_seconds,
+        allow_remote,
+    ):
+        actions, report = call_openpi_policy(
+            observation,
+            endpoint=endpoint,
+            timeout_seconds=timeout_seconds,
+            allow_remote=allow_remote,
+            layout=observation_layout,
+            state_key=state_key,
+            prompt_key=prompt_key,
+        )
+        return actions, _json(report)
+
+
+class VLAGr00tZMQPolicy:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "observation": (VLA_OBSERVATION,),
+                "host": (
+                    "STRING",
+                    {"default": "127.0.0.1", "dynamicPrompts": False},
+                ),
+                "port": (
+                    "INT",
+                    {"default": 5555, "min": 1, "max": 65_535, "step": 1},
+                ),
+                "timeout_seconds": (
+                    "FLOAT",
+                    {"default": 120.0, "min": 0.1, "max": 600.0, "step": 1.0},
+                ),
+                "allow_remote": ("BOOLEAN", {"default": False}),
+            }
+        }
+
+    RETURN_TYPES = (VLA_ACTIONS, "STRING")
+    RETURN_NAMES = ("actions", "inference_report")
+    FUNCTION = "infer"
+    CATEGORY = "VLM Nodes/Robotics/Policies"
+    DESCRIPTION = (
+        "Native client for the official Isaac-GR00T N1.7 ZeroMQ policy server. "
+        "GROOT_API_TOKEN stays in the environment; no hardware commands are emitted."
+    )
+
+    def infer(self, observation, host, port, timeout_seconds, allow_remote):
+        actions, report = call_groot_policy(
+            observation,
+            host=host,
+            port=port,
+            timeout_seconds=timeout_seconds,
+            allow_remote=allow_remote,
+        )
+        return actions, _json(report)
+
+
+class VLAActionSafety:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "actions": (VLA_ACTIONS,),
+                "embodiment": (VLA_EMBODIMENT,),
+                "mode": (SAFETY_MODES, {"default": "Block unsafe"}),
+                "execution_horizon": (
+                    "INT",
+                    {"default": 8, "min": 1, "max": MAX_ACTION_HORIZON, "step": 1},
+                ),
+                "previous_action_json": (
+                    "STRING",
+                    {"default": "", "multiline": True, "dynamicPrompts": False},
+                ),
+            }
+        }
+
+    RETURN_TYPES = (VLA_ACTIONS, "STRING", "BOOLEAN")
+    RETURN_NAMES = ("safe_actions", "safety_report", "safe_for_handoff")
+    FUNCTION = "validate"
+    CATEGORY = "VLM Nodes/Robotics/Safety"
+    DESCRIPTION = (
+        "Validate dimensions, finite values, bounds, per-step deltas, and "
+        "execution horizon. This does not replace a hardware safety controller."
+    )
+
+    def validate(
+        self,
+        actions,
+        embodiment,
+        mode,
+        execution_horizon,
+        previous_action_json,
+    ):
+        safe_actions, report = validate_action_trajectory(
+            actions,
+            embodiment,
+            mode=mode,
+            execution_horizon=execution_horizon,
+            previous_action_json=previous_action_json,
+        )
+        return safe_actions, _json(report), report["safe_for_handoff"]
+
+
+class VLAActionsFromJSON:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "actions_json": (
+                    "STRING",
+                    {
+                        "default": "[[0, 0, 0, 0, 0, 0, 0, 0]]",
+                        "multiline": True,
+                        "dynamicPrompts": False,
+                    },
+                )
+            }
+        }
+
+    RETURN_TYPES = (VLA_ACTIONS, "STRING")
+    RETURN_NAMES = ("actions", "actions_summary")
+    FUNCTION = "parse"
+    CATEGORY = "VLM Nodes/Robotics/Actions"
+    DESCRIPTION = (
+        "Parse a raw numeric action array, named action-stream object, or "
+        "versioned VLA action JSON for replay, simulation, and testing."
+    )
+
+    def parse(self, actions_json):
+        actions = actions_from_json(actions_json)
+        return actions, _json(actions.to_dict())
+
+
+class VLAActionChunkReplan:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "previous_actions": (VLA_ACTIONS,),
+                "new_actions": (VLA_ACTIONS,),
+                "executed_steps": (
+                    "INT",
+                    {"default": 1, "min": 0, "max": MAX_ACTION_HORIZON, "step": 1},
+                ),
+                "transition_steps": (
+                    "INT",
+                    {"default": 2, "min": 0, "max": 128, "step": 1},
+                ),
+                "max_horizon": (
+                    "INT",
+                    {
+                        "default": 16,
+                        "min": 1,
+                        "max": MAX_ACTION_HORIZON,
+                        "step": 1,
+                    },
+                ),
+            }
+        }
+
+    RETURN_TYPES = (VLA_ACTIONS, "STRING")
+    RETURN_NAMES = ("replanned_actions", "replan_report")
+    FUNCTION = "replan"
+    CATEGORY = "VLM Nodes/Robotics/Actions"
+    DESCRIPTION = (
+        "Blend the unexecuted edge of a previous chunk into a new plan to "
+        "reduce chunk-boundary discontinuities. Validate the result afterward."
+    )
+
+    def replan(
+        self,
+        previous_actions,
+        new_actions,
+        executed_steps,
+        transition_steps,
+        max_horizon,
+    ):
+        actions, report = blend_action_chunks(
+            previous_actions,
+            new_actions,
+            executed_steps=executed_steps,
+            transition_steps=transition_steps,
+            max_horizon=max_horizon,
+        )
+        return actions, _json(report)
+
+
+class VLAActionInspect:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "actions": (VLA_ACTIONS,),
+                "step_index": (
+                    "INT",
+                    {"default": 0, "min": 0, "max": MAX_ACTION_HORIZON - 1, "step": 1},
+                ),
+            }
+        }
+
+    RETURN_TYPES = ("STRING", "STRING", "INT", "INT")
+    RETURN_NAMES = ("trajectory_json", "selected_step_json", "horizon", "action_dim")
+    FUNCTION = "inspect"
+    CATEGORY = "VLM Nodes/Robotics/Actions"
+    DESCRIPTION = (
+        "Serialize a validated action trajectory and inspect one step. "
+        "It never writes to a robot transport."
+    )
+
+    def inspect(self, actions, step_index):
+        if not isinstance(actions, RobotActions):
+            raise TypeError("actions must be a VLA action trajectory.")
+        index = int(step_index)
+        if not 0 <= index < actions.horizon:
+            raise IndexError(
+                f"step_index {index} is outside the trajectory horizon {actions.horizon}."
+            )
+        step = {
+            "schema": "comfyui-vlm/robot-action-step",
+            "version": ROBOTICS_SCHEMA_VERSION,
+            "source": actions.source,
+            "step_index": index,
+            "action": {
+                name: float(value)
+                for name, value in zip(
+                    actions.action_names,
+                    actions.values[index].tolist(),
+                    strict=True,
+                )
+            },
+        }
+        return (
+            _json(actions.to_dict()),
+            _json(step),
+            actions.horizon,
+            actions.action_dim,
+        )
+
+
+class VLATrajectoryPreview:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "actions": (VLA_ACTIONS,),
+                "width": ("INT", {"default": 960, "min": 320, "max": 2048, "step": 16}),
+                "height": ("INT", {"default": 480, "min": 240, "max": 1536, "step": 16}),
+            },
+            "optional": {"embodiment": (VLA_EMBODIMENT,)},
+        }
+
+    RETURN_TYPES = ("IMAGE",)
+    RETURN_NAMES = ("trajectory_plot",)
+    FUNCTION = "render"
+    CATEGORY = "VLM Nodes/Robotics/Actions"
+    DESCRIPTION = "Render every predicted action dimension as a workflow preview."
+
+    def render(self, actions, width, height, embodiment=None):
+        return (render_action_preview(actions, embodiment=embodiment, width=width, height=height),)
+
+
+class VLAModelCatalog:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "model": (VLA_MODEL_LABELS, {"default": VLA_MODEL_LABELS[0]}),
+            }
+        }
+
+    RETURN_TYPES = ("STRING", "STRING", "STRING", "STRING")
+    RETURN_NAMES = ("model_info_json", "checkpoint", "policy_type", "backend")
+    FUNCTION = "lookup"
+    CATEGORY = "VLM Nodes/Robotics"
+    DESCRIPTION = (
+        "Curated official VLA runtime/checkpoint map. Entries distinguish "
+        "robot-ready fine-tunes from base or architecture-only research models."
+    )
+
+    def lookup(self, model):
+        info = VLA_MODEL_CATALOG[model]
+        return _json(info.to_dict()), info.checkpoint, info.policy_type, info.backend
+
+
+NODE_CLASS_MAPPINGS = {
+    "VLAEmbodimentProfile": VLAEmbodimentProfile,
+    "VLAObservationBuilder": VLAObservationBuilder,
+    "VLAHTTPPolicy": VLAHTTPPolicy,
+    "VLAOpenPIWebSocketPolicy": VLAOpenPIWebSocketPolicy,
+    "VLAGr00tZMQPolicy": VLAGr00tZMQPolicy,
+    "VLAActionSafety": VLAActionSafety,
+    "VLAActionsFromJSON": VLAActionsFromJSON,
+    "VLAActionChunkReplan": VLAActionChunkReplan,
+    "VLAActionInspect": VLAActionInspect,
+    "VLATrajectoryPreview": VLATrajectoryPreview,
+    "VLAModelCatalog": VLAModelCatalog,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "VLAEmbodimentProfile": "VLA Embodiment Profile",
+    "VLAObservationBuilder": "VLA Observation Builder",
+    "VLAHTTPPolicy": "VLA Policy — Universal HTTP",
+    "VLAOpenPIWebSocketPolicy": "VLA Policy — OpenPI WebSocket",
+    "VLAGr00tZMQPolicy": "VLA Policy — GR00T N1.7 ZMQ",
+    "VLAActionSafety": "VLA Action Safety Gate",
+    "VLAActionsFromJSON": "VLA Actions From JSON",
+    "VLAActionChunkReplan": "VLA Action Chunk Replan",
+    "VLAActionInspect": "VLA Action Inspect",
+    "VLATrajectoryPreview": "VLA Trajectory Preview",
+    "VLAModelCatalog": "VLA Model Catalog",
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "comfyui_vlm_nodes"
-version = "3.3.1"
+version = "3.4.0"
 description = "Production-ready local and API vision-language nodes for ComfyUI"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -46,6 +46,11 @@ quantization = [
 ]
 gguf = [
   "llama-cpp-python>=0.3.20,<1",
+]
+robotics-client = [
+  "msgpack>=1.0.8,<2",
+  "pyzmq>=26,<28",
+  "websockets>=14,<17",
 ]
 
 [project.urls]
@@ -95,6 +100,7 @@ Icon = ""
 packages = [
   "comfyui_vlm_nodes",
   "comfyui_vlm_nodes.examples",
+  "comfyui_vlm_nodes.examples.robotics",
   "comfyui_vlm_nodes.examples.vision",
   "comfyui_vlm_nodes.nodes",
   "comfyui_vlm_nodes.nodes.joytagger",
@@ -111,6 +117,9 @@ comfyui_vlm_nodes = [
   "*.json",
   "SECURITY.md",
   "examples/*.json",
+  "examples/robotics/*.py",
+  "examples/robotics/*.md",
+  "examples/robotics/*.json",
   "examples/vision/*.json",
   "requirements*.txt",
 ]

--- a/requirements-robotics-client.txt
+++ b/requirements-robotics-client.txt
@@ -1,0 +1,5 @@
+# Lightweight native clients only. Heavy VLA policy runtimes stay in a
+# separate LeRobot, openpi, GR00T, OpenVLA/OFT, or Octo environment.
+msgpack>=1.0.8,<2
+pyzmq>=26,<28
+websockets>=14,<17

--- a/tests/manual_robotics_smoke.py
+++ b/tests/manual_robotics_smoke.py
@@ -1,0 +1,158 @@
+"""Queue a real robotics policy workflow through ComfyUI's local API.
+
+This is intentionally excluded from pytest: it requires a running ComfyUI
+server, a running policy sidecar, a real image in ComfyUI's input directory,
+and downloaded policy weights.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+import urllib.request
+import uuid
+
+
+def _graph(image: str, policy_endpoint: str) -> dict:
+    camera_names = [
+        "observation.images.camera1",
+        "observation.images.camera2",
+        "observation.images.camera3",
+    ]
+    return {
+        "1": {"class_type": "LoadImage", "inputs": {"image": image}},
+        "12": {
+            "class_type": "ImageScale",
+            "inputs": {
+                "image": ["1", 0],
+                "upscale_method": "lanczos",
+                "width": 256,
+                "height": 256,
+                "crop": "center",
+            },
+        },
+        "2": {
+            "class_type": "VLAEmbodimentProfile",
+            "inputs": {
+                "preset": "LeRobot SO-100 / SO-101 template",
+                "control_hz": 30.0,
+                "state_names_json": "",
+                "action_names_json": "",
+                "action_min_json": "",
+                "action_max_json": "",
+                "max_delta_json": "",
+                "camera_names_json": json.dumps(camera_names),
+                "action_mode_override": "",
+            },
+        },
+        "3": {
+            "class_type": "VLAObservationBuilder",
+            "inputs": {
+                "task": (
+                    "Move the end effector toward the backpack and prepare to grasp it."
+                ),
+                "state_json": "[0, 0, 0, 0, 0, 0]",
+                "primary_image": ["12", 0],
+                "primary_camera": camera_names[0],
+                "history_fps": 10.0,
+                "timestamp": 0.0,
+                "embodiment": ["2", 0],
+                "wrist_image": ["12", 0],
+                "wrist_camera": camera_names[1],
+                "secondary_image": ["12", 0],
+                "secondary_camera": camera_names[2],
+            },
+        },
+        "4": {
+            "class_type": "VLAHTTPPolicy",
+            "inputs": {
+                "observation": ["3", 0],
+                "endpoint": policy_endpoint,
+                "timeout_seconds": 120.0,
+                "include_history": True,
+                "allow_remote": False,
+            },
+        },
+        "5": {
+            "class_type": "VLAActionSafety",
+            "inputs": {
+                "actions": ["4", 0],
+                "embodiment": ["2", 0],
+                "mode": "Clamp safely",
+                "execution_horizon": 4,
+                "previous_action_json": "[0, 0, 0, 0, 0, 0]",
+            },
+        },
+        "6": {
+            "class_type": "VLATrajectoryPreview",
+            "inputs": {
+                "actions": ["5", 0],
+                "width": 960,
+                "height": 480,
+                "embodiment": ["2", 0],
+            },
+        },
+        "7": {
+            "class_type": "VLAActionInspect",
+            "inputs": {"actions": ["5", 0], "step_index": 0},
+        },
+        "8": {"class_type": "PreviewImage", "inputs": {"images": ["6", 0]}},
+        "9": {"class_type": "ViewText", "inputs": {"text": ["4", 1]}},
+        "10": {"class_type": "ViewText", "inputs": {"text": ["5", 1]}},
+        "11": {"class_type": "ViewText", "inputs": {"text": ["7", 0]}},
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--comfy-url", default="http://127.0.0.1:8188")
+    parser.add_argument("--policy-url", default="http://127.0.0.1:8787")
+    parser.add_argument(
+        "--image",
+        required=True,
+        help="Filename relative to the running ComfyUI instance's input directory.",
+    )
+    parser.add_argument("--timeout", type=float, default=180.0)
+    args = parser.parse_args()
+
+    base = args.comfy_url.rstrip("/")
+    body = json.dumps(
+        {
+            "prompt": _graph(args.image, args.policy_url),
+            "client_id": str(uuid.uuid4()),
+        }
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        f"{base}/prompt",
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        queued = json.load(response)
+    prompt_id = queued["prompt_id"]
+    deadline = time.monotonic() + args.timeout
+    while time.monotonic() < deadline:
+        with urllib.request.urlopen(
+            f"{base}/history/{prompt_id}",
+            timeout=10,
+        ) as response:
+            history = json.load(response)
+        if prompt_id not in history:
+            time.sleep(0.5)
+            continue
+        entry = history[prompt_id]
+        result = {
+            "prompt_id": prompt_id,
+            "status": entry.get("status"),
+            "outputs": entry.get("outputs"),
+        }
+        print(json.dumps(result, indent=2))
+        if entry.get("status", {}).get("status_str") != "success":
+            raise SystemExit(1)
+        return
+    raise SystemExit(f"Timed out waiting for prompt {prompt_id}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_robotics.py
+++ b/tests/test_robotics.py
@@ -1,0 +1,758 @@
+import json
+import re
+import threading
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+from ComfyUI_VLM_nodes.examples.robotics import lerobot_policy_server
+from ComfyUI_VLM_nodes.nodes import robotics
+from ComfyUI_VLM_nodes.nodes.robotics import (
+    EMBODIMENT_SCHEMA,
+    VLA_MODEL_CATALOG,
+    RobotActions,
+    actions_from_json,
+    actions_from_response,
+    blend_action_chunks,
+    build_observation,
+    make_embodiment,
+    observation_to_groot_payload,
+    observation_to_http_payload,
+    observation_to_openpi_payload,
+    render_action_preview,
+    validate_action_trajectory,
+    validate_policy_url,
+    validate_ws_url,
+    validate_zmq_host,
+)
+
+
+def _image(frames=1, height=24, width=32):
+    return torch.linspace(0, 1, frames * height * width * 3).reshape(
+        frames, height, width, 3
+    )
+
+
+def _joint_profile():
+    return make_embodiment("Generic 7-DoF joint + gripper")
+
+
+def _observation(profile=None):
+    profile = profile or _joint_profile()
+    return build_observation(
+        task="Pick up the blue cube.",
+        state_json=json.dumps([0.0] * profile.state_dim),
+        primary_image=_image(frames=3),
+        primary_camera=profile.camera_names[0],
+        history_fps=15,
+        timestamp=12.5,
+        embodiment=profile,
+    )
+
+
+def test_embodiment_presets_are_explicit_roundtrippable_contracts():
+    for preset in robotics.EMBODIMENT_PRESETS:
+        profile = make_embodiment(preset)
+        encoded = profile.to_dict()
+        assert encoded["schema"] == EMBODIMENT_SCHEMA
+        assert len(encoded["action_names"]) == len(encoded["action_min"])
+        assert len(encoded["action_names"]) == len(encoded["action_max"])
+        assert len(encoded["action_names"]) == len(encoded["max_delta_per_step"])
+        assert robotics.RobotEmbodiment.from_dict(encoded) == profile
+        assert "Template limits" in profile.notes
+
+
+def test_embodiment_rejects_invalid_bounds_and_mismatched_overrides():
+    with pytest.raises(ValueError, match="smaller"):
+        robotics.RobotEmbodiment(
+            name="bad",
+            state_names=("s",),
+            action_names=("a",),
+            action_min=(1,),
+            action_max=(0,),
+            max_delta=(0.1,),
+            control_hz=10,
+            action_mode="absolute",
+            camera_names=("front",),
+        )
+    with pytest.raises(ValueError, match="must contain 8"):
+        make_embodiment(
+            "Generic 7-DoF joint + gripper",
+            action_min=[-1],
+        )
+
+
+def test_observation_preserves_history_and_validates_state_and_cameras():
+    profile = _joint_profile()
+    observation = _observation(profile)
+    summary = observation.summary()
+    assert summary["history_frames"] == 3
+    assert summary["cameras"][profile.camera_names[0]]["width"] == 32
+    assert summary["state"] == [0.0] * 8
+    assert summary["task"] == "Pick up the blue cube."
+
+    with pytest.raises(ValueError, match="State dimension"):
+        build_observation(
+            task="move",
+            state_json="[0]",
+            primary_image=_image(),
+            primary_camera=profile.camera_names[0],
+            history_fps=10,
+            timestamp=0,
+            embodiment=profile,
+        )
+    with pytest.raises(ValueError, match="not declared"):
+        build_observation(
+            task="move",
+            state_json=json.dumps([0] * profile.state_dim),
+            primary_image=_image(),
+            primary_camera="unknown",
+            history_fps=10,
+            timestamp=0,
+            embodiment=profile,
+        )
+
+
+def test_http_payload_is_bounded_and_contains_no_tensor_details():
+    payload = observation_to_http_payload(_observation(), include_history=True)
+    assert payload["schema"] == "comfyui-vlm/robot-observation"
+    camera_frames = next(iter(payload["cameras"].values()))
+    assert len(camera_frames) == 3
+    assert all(item["encoding"] == "base64-jpeg" for item in camera_frames)
+    assert "device" not in json.dumps(payload)
+
+
+def test_openpi_payload_supports_flat_and_aloha_shapes():
+    observation = _observation()
+    flat = observation_to_openpi_payload(
+        observation,
+        layout="Flat keys (DROID / LIBERO)",
+        state_key="observation/state",
+        prompt_key="prompt",
+    )
+    camera_key = observation.images[0][0]
+    assert flat[camera_key].shape == (24, 32, 3)
+    assert flat[camera_key].dtype == np.uint8
+    assert flat["observation/state"].dtype == np.float32
+
+    nested = observation_to_openpi_payload(
+        observation,
+        layout="Nested images (ALOHA)",
+        state_key="state",
+        prompt_key="prompt",
+    )
+    assert nested["images"][camera_key].shape == (3, 24, 32)
+
+
+def test_openpi_array_codec_roundtrips_and_rejects_object_arrays():
+    import msgpack
+
+    source = np.arange(12, dtype=np.float32).reshape(3, 4)
+    encoded = msgpack.packb({"actions": source}, default=robotics._openpi_pack_array)
+    decoded = msgpack.unpackb(encoded, object_hook=robotics._openpi_unpack_array)
+    key = b"actions" if b"actions" in decoded else "actions"
+    assert np.array_equal(decoded[key], source)
+    with pytest.raises(ValueError, match="does not support dtype"):
+        robotics._openpi_pack_array(np.array([object()], dtype=object))
+    forged = {
+        b"__ndarray__": True,
+        b"data": b"",
+        b"dtype": "|O",
+        b"shape": (0,),
+    }
+    with pytest.raises(ValueError, match="unsafe"):
+        robotics._openpi_unpack_array(forged)
+
+
+def test_openpi_client_protocol_and_token_redaction(monkeypatch):
+    sent = []
+
+    class Connection:
+        responses = [b"metadata", b"actions"]
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            pass
+
+        def recv(self, timeout):
+            assert timeout == 5
+            return self.responses.pop(0)
+
+        def send(self, value):
+            sent.append(value)
+
+    connect_calls = []
+
+    def connect(uri, **kwargs):
+        connect_calls.append((uri, kwargs))
+        return Connection()
+
+    fake_ws = SimpleNamespace(connect=connect)
+
+    class FakeMsgpack:
+        @staticmethod
+        def packb(value, default):
+            assert value["prompt"] == "Pick up the blue cube."
+            assert callable(default)
+            return b"encoded-request"
+
+        @staticmethod
+        def unpackb(value, object_hook):
+            assert callable(object_hook)
+            if value == b"metadata":
+                return {"model": "pi-test"}
+            return {
+                "actions": np.zeros((2, 8), dtype=np.float32),
+                "server_timing": {"infer_ms": 12.5},
+            }
+
+    def fake_require(name, *_args):
+        return fake_ws if name == "websockets.sync.client" else FakeMsgpack
+
+    monkeypatch.setattr(robotics, "require_module", fake_require)
+    monkeypatch.setenv("OPENPI_API_KEY", "openpi-secret")
+    actions, report = robotics.call_openpi_policy(
+        _observation(),
+        endpoint="ws://127.0.0.1:8000",
+        timeout_seconds=5,
+        allow_remote=False,
+        layout="Flat keys (DROID / LIBERO)",
+        state_key="observation/state",
+        prompt_key="prompt",
+    )
+    assert actions.values.shape == (2, 8)
+    assert sent == [b"encoded-request"]
+    assert connect_calls[0][1]["additional_headers"] == {
+        "Authorization": "Api-Key openpi-secret"
+    }
+    assert report["server_metadata"] == {"model": "pi-test"}
+    assert "openpi-secret" not in json.dumps(report)
+
+    def broken_connect(*_args, **_kwargs):
+        raise RuntimeError("token=openpi-secret")
+
+    fake_ws.connect = broken_connect
+    with pytest.raises(RuntimeError, match=r"token=\[REDACTED\]") as exc:
+        robotics.call_openpi_policy(
+            _observation(),
+            endpoint="ws://127.0.0.1:8000",
+            timeout_seconds=5,
+            allow_remote=False,
+            layout="Flat keys (DROID / LIBERO)",
+            state_key="observation/state",
+            prompt_key="prompt",
+        )
+    assert "openpi-secret" not in str(exc.value)
+
+
+def test_groot_payload_uses_official_nested_batch_time_contract():
+    observation = _observation()
+    payload = observation_to_groot_payload(observation)
+    camera = next(iter(payload["video"].values()))
+    assert camera.shape == (1, 3, 24, 32, 3)
+    assert camera.dtype == np.uint8
+    assert payload["state"]["state"].shape == (1, 3, 8)
+    assert payload["state"]["state"].dtype == np.float32
+    assert payload["language"]["task"] == [["Pick up the blue cube."]]
+
+
+def test_groot_array_codec_and_native_client(monkeypatch):
+    import msgpack
+
+    array = np.arange(6, dtype=np.float32).reshape(2, 3)
+    encoded = msgpack.packb({"x": array}, default=robotics._groot_encode)
+    decoded = msgpack.unpackb(encoded, object_hook=robotics._groot_decode, raw=False)
+    assert np.array_equal(decoded["x"], array)
+    with pytest.raises(TypeError, match="object/void"):
+        robotics._groot_encode(np.array([object()], dtype=object))
+    with pytest.raises(ValueError, match="object/void"):
+        robotics._groot_decode({"nd": True, "kind": "O", "type": "|O"})
+
+    sockets = []
+
+    class Socket:
+        def __init__(self):
+            self.options = []
+            self.connected = None
+            self.request = None
+            self.closed = False
+
+        def setsockopt(self, key, value):
+            self.options.append((key, value))
+
+        def connect(self, value):
+            self.connected = value
+
+        def send(self, value):
+            self.request = value
+
+        def recv(self):
+            return b"response"
+
+        def close(self, linger):
+            assert linger == 0
+            self.closed = True
+
+    class Context:
+        terminated = False
+
+        def socket(self, kind):
+            assert kind == 1
+            socket = Socket()
+            sockets.append(socket)
+            return socket
+
+        def term(self):
+            self.terminated = True
+
+    fake_zmq = SimpleNamespace(
+        REQ=1,
+        RCVTIMEO=2,
+        SNDTIMEO=3,
+        LINGER=4,
+        Context=Context,
+    )
+    packed_requests = []
+
+    class FakeMsgpack:
+        @staticmethod
+        def packb(value, default):
+            packed_requests.append(value)
+            assert callable(default)
+            return b"request"
+
+        @staticmethod
+        def unpackb(value, object_hook, raw):
+            assert value == b"response"
+            assert callable(object_hook)
+            assert raw is False
+            return [
+                {
+                    "arm": np.zeros((1, 3, 7), dtype=np.float32),
+                    "gripper": np.ones((1, 3, 1), dtype=np.float32),
+                },
+                {"server": "ok"},
+            ]
+
+    def fake_require(name, *_args):
+        return fake_zmq if name == "zmq" else FakeMsgpack
+
+    monkeypatch.setattr(robotics, "require_module", fake_require)
+    monkeypatch.setenv("GROOT_API_TOKEN", "groot-secret")
+    actions, report = robotics.call_groot_policy(
+        _observation(),
+        host="127.0.0.1",
+        port=5555,
+        timeout_seconds=3,
+        allow_remote=False,
+    )
+    assert actions.values.shape == (3, 8)
+    assert actions.stream_slices == (("arm", 0, 7), ("gripper", 7, 8))
+    assert packed_requests[0]["api_token"] == "groot-secret"
+    assert sockets[0].connected == "tcp://127.0.0.1:5555"
+    assert sockets[0].closed is True
+    assert report["policy_info"] == {"server": "ok"}
+    assert "groot-secret" not in json.dumps(report)
+
+
+def test_action_response_parses_arrays_and_named_streams():
+    single = actions_from_response(
+        {"actions": [[[1, 2], [3, 4]]]},
+        source="test",
+    )
+    assert single.values.shape == (2, 2)
+    assert single.stream_slices == (("actions", 0, 2),)
+
+    streams = actions_from_response(
+        {
+            "arm": np.zeros((1, 4, 7), dtype=np.float32),
+            "gripper": np.ones((1, 4, 1), dtype=np.float32),
+            "info": {"ignored": True},
+        },
+        source="groot",
+    )
+    assert streams.values.shape == (4, 8)
+    assert streams.stream_slices == (("arm", 0, 7), ("gripper", 7, 8))
+
+
+def test_actions_json_roundtrip_and_chunk_replanning():
+    profile = _joint_profile()
+    previous = RobotActions(
+        torch.zeros((5, 8)),
+        profile.action_names,
+        "previous",
+    )
+    new = RobotActions(
+        torch.ones((6, 8)),
+        profile.action_names,
+        "new",
+    )
+    parsed = actions_from_json(json.dumps(new.to_dict()))
+    assert torch.equal(parsed.values, new.values)
+    assert parsed.action_names == new.action_names
+
+    replanned, report = blend_action_chunks(
+        previous,
+        new,
+        executed_steps=2,
+        transition_steps=2,
+        max_horizon=4,
+    )
+    assert replanned.values.shape == (4, 8)
+    assert torch.allclose(replanned.values[0], torch.full((8,), 1 / 3))
+    assert torch.allclose(replanned.values[1], torch.full((8,), 2 / 3))
+    assert torch.equal(replanned.values[2:], torch.ones((2, 8)))
+    assert report["transition_steps_applied"] == 2
+    with pytest.raises(ValueError, match="outside"):
+        blend_action_chunks(
+            previous,
+            new,
+            executed_steps=99,
+            transition_steps=2,
+            max_horizon=4,
+        )
+
+
+def test_action_safety_clamps_bounds_deltas_and_horizon():
+    profile = _joint_profile()
+    values = torch.tensor(
+        [
+            [4.0, 0, 0, 0, 0, 0, 0, 2.0],
+            [-4.0, 0, 0, 0, 0, 0, 0, -2.0],
+            [0.0, 0, 0, 0, 0, 0, 0, 0.5],
+        ]
+    )
+    actions = RobotActions(
+        values=values,
+        action_names=profile.action_names,
+        source="unit",
+    )
+    safe, report = validate_action_trajectory(
+        actions,
+        profile,
+        mode="Clamp safely",
+        execution_horizon=2,
+        previous_action_json=json.dumps([0.0] * 8),
+    )
+    assert safe.horizon == 2
+    assert torch.all(safe.values <= torch.tensor(profile.action_max))
+    assert torch.all(safe.values >= torch.tensor(profile.action_min))
+    limits = torch.tensor(profile.max_delta)
+    previous = torch.zeros(8)
+    for step in safe.values:
+        assert torch.all((step - previous).abs() <= limits + 1.0e-6)
+        previous = step
+    assert report["violations"]["total"] > 0
+    assert report["changed"] is True
+    assert report["safe_for_handoff"] is True
+
+
+def test_action_safety_blocks_or_holds_nonfinite_actions():
+    profile = _joint_profile()
+    values = torch.zeros((2, 8))
+    values[0, 2] = float("nan")
+    actions = RobotActions(values, profile.action_names, "unit")
+    with pytest.raises(ValueError, match="blocked"):
+        validate_action_trajectory(
+            actions,
+            profile,
+            mode="Block unsafe",
+            execution_horizon=2,
+        )
+    held, report = validate_action_trajectory(
+        actions,
+        profile,
+        mode="Hold position on unsafe",
+        execution_horizon=2,
+        previous_action_json=json.dumps([0.25] * 8),
+    )
+    assert torch.allclose(held.values, torch.full((2, 8), 0.25))
+    assert report["safe_for_handoff"] is True
+    with pytest.raises(ValueError, match="requires previous_action_json"):
+        validate_action_trajectory(
+            actions,
+            profile,
+            mode="Hold position on unsafe",
+            execution_horizon=2,
+        )
+
+
+def test_action_json_rejects_nonfinite_before_serialization():
+    actions = RobotActions(
+        torch.tensor([[float("inf")]]),
+        ("action",),
+        "unit",
+    )
+    with pytest.raises(ValueError, match="NaN or infinity"):
+        actions.to_dict()
+
+
+def test_policy_endpoint_security_defaults():
+    assert (
+        validate_policy_url("http://127.0.0.1:8787", allow_remote=False)
+        == "http://127.0.0.1:8787/v1/infer"
+    )
+    assert validate_policy_url(
+        "https://policy.example/v1/infer",
+        allow_remote=True,
+    ) == "https://policy.example/v1/infer"
+    with pytest.raises(ValueError, match="HTTPS"):
+        validate_policy_url("http://policy.example", allow_remote=True)
+    with pytest.raises(ValueError, match="disabled"):
+        validate_policy_url("https://policy.example", allow_remote=False)
+    with pytest.raises(ValueError, match="embedded credentials"):
+        validate_policy_url("https://secret@example.com", allow_remote=True)
+
+    assert validate_ws_url("127.0.0.1:8000", allow_remote=False) == "ws://127.0.0.1:8000"
+    with pytest.raises(ValueError, match="WSS"):
+        validate_ws_url("ws://policy.example", allow_remote=True)
+    assert validate_zmq_host("localhost", allow_remote=False) == "localhost"
+    with pytest.raises(ValueError, match="disabled"):
+        validate_zmq_host("policy.example", allow_remote=False)
+
+
+class _PolicyHandler(BaseHTTPRequestHandler):
+    observed_auth = None
+    observed_payload = None
+
+    def log_message(self, *_args):
+        pass
+
+    def do_POST(self):  # noqa: N802
+        type(self).observed_auth = self.headers.get("Authorization")
+        length = int(self.headers["Content-Length"])
+        type(self).observed_payload = json.loads(self.rfile.read(length))
+        body = json.dumps(
+            {
+                "actions": [[0.0] * 8, [0.1] * 8],
+                "action_names": [f"a{index}" for index in range(8)],
+            }
+        ).encode()
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def test_http_policy_real_loopback_request_uses_env_token_without_leaking(monkeypatch):
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _PolicyHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    monkeypatch.setenv("VLA_POLICY_TOKEN", "top-secret-value")
+    try:
+        actions, report = robotics.call_http_policy(
+            _observation(),
+            endpoint=f"http://127.0.0.1:{server.server_port}",
+            timeout_seconds=5,
+            allow_remote=False,
+            include_history=False,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+    assert actions.values.shape == (2, 8)
+    assert _PolicyHandler.observed_auth == "Bearer top-secret-value"
+    assert _PolicyHandler.observed_payload["task"] == "Pick up the blue cube."
+    assert report["authenticated"] is True
+    assert "top-secret-value" not in json.dumps(report)
+    assert "top-secret-value" not in repr(actions)
+
+
+def test_http_policy_error_redacts_server_token(monkeypatch):
+    class BrokenClient:
+        def __init__(self, **_kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            pass
+
+        def stream(self, *_args, **_kwargs):
+            raise RuntimeError("Authorization: Bearer secret-http-token")
+
+    monkeypatch.setenv("VLA_POLICY_TOKEN", "secret-http-token")
+    monkeypatch.setattr(
+        robotics,
+        "require_module",
+        lambda *_args: SimpleNamespace(Client=BrokenClient),
+    )
+    with pytest.raises(RuntimeError) as exc:
+        robotics.call_http_policy(
+            _observation(),
+            endpoint="http://127.0.0.1:8787",
+            timeout_seconds=5,
+            allow_remote=False,
+            include_history=False,
+        )
+    assert "secret-http-token" not in str(exc.value)
+    assert "[REDACTED]" in str(exc.value)
+
+
+def test_http_policy_rejects_declared_oversized_response(monkeypatch):
+    class Response:
+        headers = {
+            "content-length": str(robotics.MAX_HTTP_RESPONSE_BYTES + 1),
+        }
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            pass
+
+        def raise_for_status(self):
+            pass
+
+        def iter_bytes(self):
+            raise AssertionError("Oversized response body must not be read.")
+
+    class Client:
+        def __init__(self, **_kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            pass
+
+        def stream(self, *_args, **_kwargs):
+            return Response()
+
+    monkeypatch.setattr(
+        robotics,
+        "require_module",
+        lambda *_args: SimpleNamespace(Client=Client),
+    )
+    with pytest.raises(RuntimeError, match="32 MiB"):
+        robotics.call_http_policy(
+            _observation(),
+            endpoint="http://127.0.0.1:8787",
+            timeout_seconds=5,
+            allow_remote=False,
+            include_history=False,
+        )
+
+
+def test_catalog_has_unique_official_entries_and_clear_readiness():
+    assert 12 <= len(VLA_MODEL_CATALOG) <= 30
+    checkpoints = []
+    for label, info in VLA_MODEL_CATALOG.items():
+        assert label == info.label
+        assert info.official_url.startswith("https://")
+        assert info.backend
+        assert info.status
+        if info.checkpoint:
+            checkpoints.append(info.checkpoint)
+    assert len(checkpoints) == len(set(checkpoints))
+    assert any(info.family == "SmolVLA" for info in VLA_MODEL_CATALOG.values())
+    assert any(info.family == "Isaac GR00T N1.7" for info in VLA_MODEL_CATALOG.values())
+    assert any(info.family == "OpenVLA-OFT" for info in VLA_MODEL_CATALOG.values())
+
+
+def test_trajectory_preview_is_a_comfy_image():
+    profile = _joint_profile()
+    actions = RobotActions(
+        torch.linspace(-0.5, 0.5, 5 * 8).reshape(5, 8),
+        profile.action_names,
+        "preview",
+    )
+    preview = render_action_preview(actions, embodiment=profile, width=640, height=320)
+    assert preview.shape == (1, 320, 640, 3)
+    assert preview.dtype == torch.float32
+    assert 0 <= float(preview.min()) <= float(preview.max()) <= 1
+
+
+def test_robotics_nodes_are_registered_and_have_safe_categories():
+    expected = {
+        "VLAEmbodimentProfile",
+        "VLAObservationBuilder",
+        "VLAHTTPPolicy",
+        "VLAOpenPIWebSocketPolicy",
+        "VLAGr00tZMQPolicy",
+        "VLAActionSafety",
+        "VLAActionsFromJSON",
+        "VLAActionChunkReplan",
+        "VLAActionInspect",
+        "VLATrajectoryPreview",
+        "VLAModelCatalog",
+    }
+    assert expected == set(robotics.NODE_CLASS_MAPPINGS)
+    for node in robotics.NODE_CLASS_MAPPINGS.values():
+        assert node.CATEGORY.startswith("VLM Nodes/Robotics")
+        assert "forceInput" not in repr(node.INPUT_TYPES())
+
+
+def test_lerobot_sidecar_is_packaged_and_avoids_pickle_transport():
+    root = Path(robotics.__file__).parents[1]
+    server = root / "examples" / "robotics" / "lerobot_policy_server.py"
+    source = server.read_text(encoding="utf-8")
+    compile(source, str(server), "exec")
+    assert "pickle.loads" not in source
+    assert "VLA_POLICY_TOKEN" in source
+    assert "ThreadingHTTPServer" in source
+
+
+def test_lerobot_sidecar_exposes_checkpoint_feature_contract(monkeypatch):
+    visual = SimpleNamespace(
+        type=SimpleNamespace(value="VISUAL"),
+        shape=(3, 256, 256),
+    )
+    action = {"type": "ACTION", "shape": (6,)}
+    assert lerobot_policy_server._feature_metadata(
+        {"observation.images.camera1": visual, "action": action}
+    ) == {
+        "observation.images.camera1": {
+            "type": "VISUAL",
+            "shape": [3, 256, 256],
+        },
+        "action": {"type": "ACTION", "shape": [6]},
+    }
+    assert lerobot_policy_server._optional_config_int(
+        SimpleNamespace(chunk_size=50), "chunk_size"
+    ) == 50
+
+    monkeypatch.setattr(
+        lerobot_policy_server,
+        "_decode_image",
+        lambda _frame: np.zeros((1, 1, 3), dtype=np.uint8),
+    )
+    oversized_task = {
+        "schema": "comfyui-vlm/robot-observation",
+        "version": 1,
+        "cameras": {
+            "observation.images.front": [
+                {"encoding": "base64-jpeg", "data": "unused"}
+            ]
+        },
+        "state": [0.0],
+        "task": "x" * (lerobot_policy_server.MAX_TASK_CHARS + 1),
+    }
+    with pytest.raises(ValueError, match="task must contain"):
+        lerobot_policy_server._decode_observation(oversized_task)
+
+
+def test_robotics_client_requirements_match_optional_extra():
+    root = Path(robotics.__file__).parents[1]
+    pyproject = (root / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r"^robotics-client\s*=\s*\[(.*?)^\]", pyproject, re.M | re.S)
+    assert match is not None
+    optional_extra = set(re.findall(r'"([^"]+)"', match.group(1)))
+    requirement_file = {
+        line.strip()
+        for line in (root / "requirements-robotics-client.txt")
+        .read_text(encoding="utf-8")
+        .splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+    assert optional_extra == requirement_file

--- a/tests/test_robotics.py
+++ b/tests/test_robotics.py
@@ -149,13 +149,10 @@ def test_openpi_payload_supports_flat_and_aloha_shapes():
 
 
 def test_openpi_array_codec_roundtrips_and_rejects_object_arrays():
-    import msgpack
-
     source = np.arange(12, dtype=np.float32).reshape(3, 4)
-    encoded = msgpack.packb({"actions": source}, default=robotics._openpi_pack_array)
-    decoded = msgpack.unpackb(encoded, object_hook=robotics._openpi_unpack_array)
-    key = b"actions" if b"actions" in decoded else "actions"
-    assert np.array_equal(decoded[key], source)
+    encoded = robotics._openpi_pack_array(source)
+    decoded = robotics._openpi_unpack_array(encoded)
+    assert np.array_equal(decoded, source)
     with pytest.raises(ValueError, match="does not support dtype"):
         robotics._openpi_pack_array(np.array([object()], dtype=object))
     forged = {
@@ -263,12 +260,10 @@ def test_groot_payload_uses_official_nested_batch_time_contract():
 
 
 def test_groot_array_codec_and_native_client(monkeypatch):
-    import msgpack
-
     array = np.arange(6, dtype=np.float32).reshape(2, 3)
-    encoded = msgpack.packb({"x": array}, default=robotics._groot_encode)
-    decoded = msgpack.unpackb(encoded, object_hook=robotics._groot_decode, raw=False)
-    assert np.array_equal(decoded["x"], array)
+    encoded = robotics._groot_encode(array)
+    decoded = robotics._groot_decode(encoded)
+    assert np.array_equal(decoded, array)
     with pytest.raises(TypeError, match="object/void"):
         robotics._groot_encode(np.array([object()], dtype=object))
     with pytest.raises(ValueError, match="object/void"):


### PR DESCRIPTION
Adds 11 robotics/VLA nodes, typed observation/action/embodiment contracts, OpenPI/GR00T/universal-HTTP clients, an isolated current-LeRobot sidecar, action safety and replanning, a 15-model catalog, examples, security guidance, and version 3.4.0. Validated with real lerobot/smolvla_base weights through ComfyUI POST /prompt; local CI: 298 tests, 73.72% coverage, Ruff, compileall, and wheel build.